### PR TITLE
Use a relative link for the Corelib library references, fixing #128

### DIFF
--- a/doc/stdlib/dune
+++ b/doc/stdlib/dune
@@ -30,7 +30,7 @@
  (action
   (progn
    (run mkdir -p html)
-   (bash "%{bin:coqdoc} -q -d html --with-header %{header} --with-footer %{footer} --multi-index --html -g -Q %{project_root}/theories Stdlib $(find %{project_root}/theories -name *.v)")
+   (bash "%{bin:coqdoc} -q -d html --with-header %{header} --with-footer %{footer} --multi-index --html -g --coqlib_url ../corelib -Q %{project_root}/theories Stdlib $(find %{project_root}/theories -name *.v)")
    (run mv html/index.html html/genindex.html)
    (with-stdout-to
      _index.html


### PR DESCRIPTION

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #128 

I think it is sound to do it like this, as long as the published documentation respects the folder layout: 

version/stdlib
version/corelib