### PR TITLE
test suite fix OS detection

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -24,8 +24,7 @@
 # Variables
 #######################################################################
 
-# An alternative is ifeq ($(OS),Windows_NT) using make's own variable.
-ifeq ($(ARCH),win32)
+ifeq ($(OS),Windows_NT)
   export FINDLIB_SEP=;
 else
   export FINDLIB_SEP=:


### PR DESCRIPTION
ARCH is from coq_config_to_make which we don't have in this repo
