### PR TITLE
memb and nodupb in ListDec.v

### DIFF
--- a/theories/Bool/Bool.v
+++ b/theories/Bool/Bool.v
@@ -963,6 +963,10 @@ Defined.
     in a unique [iff] statement, but this isn't allowed since
     [iff] is in Prop. *)
 
+Lemma reflect_iff_neg (P : Prop) (b : bool) :
+  reflect P b -> (b = false <-> ~ P).
+Proof. now intros H; split; intros ?; destruct H as [H | H]. Qed.
+
 (** Reflect implies decidability of the proposition *)
 
 Lemma reflect_dec : forall P b, reflect P b -> {P}+{~P}.


### PR DESCRIPTION
Still a draft, request for comments

- reflect_iff_false in Bool/Bool.v to help work with reflect in vanilla
- memb and nodupb in List.dec with reflection principles (some weaker, again to help with vanilla apply) : membP, memb_In, memb_nIn, nodupbP, nodupb_NoDup, nodupb_nNoDup

What I'm not so sure about :
- the whole thing is parameterized by a proof named `dec` of strong decidability of equality (in sumbool), instead of eqb together with a reflection principle of eqb (maybe write in an eqType, as in mathcomp)
- I know, these are equivalent, via bool_of_sumbool and sumbool_of_bool, but still it encourages to use a, maybe strange and changing, proof of decidability in definitions, instead of a nice boolean function

But, if we change things this way :
- Maybe take eqType and most of seq from mathcomp in StdLib ? Or part of them ? In different files ? And keep ListDec (at least serveral versions) frozen for compatibility before removal ?

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/stdlib/blob/master/CONTRIBUTING.md

Changelog: https://github.com/coq/stdlib/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/stdlib/blob/master/doc/README.md
Sphinx: https://github.com/coq/stdlib/blob/master/doc/sphinx/README.rst

Overlays: https://github.com/coq/stdlib/blob/master/dev/doc/README-CI.md
