### PR TITLE
add N.iter_op and supporting lemmas

### DIFF
--- a/doc/changelog/02-added/134-n-iter-op.rst
+++ b/doc/changelog/02-added/134-n-iter-op.rst
@@ -1,0 +1,9 @@
+- in `BinNatDef.v` and `BinNat.v`
+
+  + Added definition `Niter_op` for repeating associative operations, a proof
+    relating it to the generic :g:`N.iter` (:g:`iter_op_correct`), and
+    properties :g:`iter_op_0_r`, :g:`iter_op_1_r`, :g:`iter_op_succ_r`, and
+    :g:`iter_op_add_r`
+    (`#134 <https://github.com/coq/stdlib/pull/134>`_,
+    by Andres Erbsen).
+

--- a/doc/changelog/11-standard-library/19751-n-iter-op.rst
+++ b/doc/changelog/11-standard-library/19751-n-iter-op.rst
@@ -1,0 +1,8 @@
+- **Added:** :g:`N.iter_op` for repeating associative operations, a proof
+  relating it to the generic :g:`N.iter` (:g:`iter_op_correct`), and properties
+  :g:`iter_op_0_r`,
+  :g:`iter_op_1_r`,
+  :g:`iter_op_succ_r`,
+  and :g:`iter_op_add_r`
+  (`#19751 <https://github.com/coq/coq/pull/19751>`_,
+  by Andres Erbsen).

--- a/theories/NArith/BinNat.v
+++ b/theories/NArith/BinNat.v
@@ -1047,6 +1047,30 @@ Proof.
  intros; apply iter_ind; trivial.
 Qed.
 
+(** Properties of [iter_op] *)
+
+Lemma iter_op_0_r {A} op z x : @N.iter_op A op z x N0 = z. Proof. trivial. Qed.
+
+Lemma iter_op_1_r {A} op z x : @N.iter_op A op z x (N.pos xH) = x. Proof. trivial. Qed.
+
+Lemma iter_op_succ_r {A} op z x n
+  (opp_z_r : x = op x z)
+  (op_assoc  : forall x y z : A, op x (op y z) = op (op x y) z)
+  : @N.iter_op A op z x (N.succ n) = op x (N.iter_op op z x n).
+Proof. case n; cbn; auto using Pos.iter_op_succ. Qed.
+
+Lemma iter_op_add_r {A} op z x n
+  (opp_z_r : x = op x z)
+  (op_assoc  : forall x y z : A, op x (op y z) = op (op x y) z)
+  : @N.iter_op A op z x (N.succ n) = op x (N.iter_op op z x n).
+Proof. induction n using N.peano_ind; cbn; rewrite ?iter_op_succ_r; auto. Qed.
+
+Lemma iter_op_correct {A} op z x n
+  (opp_z_r : x = op x z)
+  (op_assoc  : forall x y z : A, op x (op y z) = op (op x y) z)
+  : @N.iter_op A op z x n = N.iter n (op x) z.
+Proof. case n; cbn; auto using Pos.iter_op_correct. Qed.
+
 End N.
 
 Bind Scope N_scope with N.t N.

--- a/theories/NArith/BinNatDef.v
+++ b/theories/NArith/BinNatDef.v
@@ -283,6 +283,11 @@ Definition iter (n:N) {A} (f:A->A) (x:A) : A :=
     | pos p => Pos.iter f x p
   end.
 
+(** Iteration of an associative operator *)
+
+Definition iter_op {A} (op : A -> A -> A) (z x : A) (n : N) :=
+  match n with N0 => z | Npos p => Pos.iter_op op p x end.
+
 (** Conversion with a decimal representation for printing/parsing *)
 
 Definition of_uint (d:Decimal.uint) := Pos.of_uint d.


### PR DESCRIPTION
Repeat of https://github.com/rocq-prover/rocq/pull/19751 which was closed without a review after 83 days. I still think this is a useful feature and should be landed.