### PR TITLE
split Zdivisibility from Znumtheory, deprecate most of Znumtheory

### DIFF
--- a/.nix/rocq-overlays/stdlib-subcomponents/default.nix
+++ b/.nix/rocq-overlays/stdlib-subcomponents/default.nix
@@ -26,9 +26,9 @@ let
     "lia" = [ "arith" "narith" ];
     "zarith" = [ "lia" ];
     "qarith-base" = [ "ring" ];
-    "field" = [ "qarith-base" "zarith" ];
-    "lqa" = [ "field" ];
-    "qarith" = [ "field" ];
+    "field" = [ "zarith" ];
+    "lqa" = [ "field" "qarith-base" ];
+    "qarith" = [ "lqa" ];
     "nsatz" = [ "zarith" "qarith-base" ];
     "classical-logic" = [ "arith" ];
     "sets" = [ "classical-logic" ];
@@ -40,7 +40,7 @@ let
     "primitive-floats" = [ "primitive-int" ];
     "primitive-array" = [ "primitive-int" ];
     "primitive-string" = [ "primitive-int" "orders-ex" ];
-    "reals" = [ "nsatz" "lqa" "qarith" "classical-logic" "vectors" ];
+    "reals" = [ "nsatz" "qarith" "classical-logic" "vectors" ];
     "fmaps-fsets-msets" = [ "orders-ex" "zarith" ];
     "extraction" = [ "primitive-string" "primitive-array" "primitive-floats" ];
     "funind" = [ "arith-base" ];

--- a/doc/changelog/01-changed/136-less-znumtheory.rst
+++ b/doc/changelog/01-changed/136-less-znumtheory.rst
@@ -1,0 +1,20 @@
+- in `ZArith,v` and dependencies
+
+  + Reducing reliance on :g:`Znumtheory` within stdlib changed the internal
+    dependencies between files, code relying on files being transitively
+    required in stdlib may need to now explicitly ``Require``
+    `Znumtheory`,
+    `BinInt`,
+    `BinList`,
+    `BinNat`,
+    `BinNums`,
+    `BinPos`,
+    `Setoid`,
+    `Tauto`,
+    `Zhints`,
+    `Zpow_def`,
+    `Zpow_facts`,
+    or `Zbool`
+    (`#136 <https://github.com/coq/stdlib/pull/136>`_,
+    by Andres Erbsen).
+

--- a/doc/changelog/02-added/136-less-znumtheory.rst
+++ b/doc/changelog/02-added/136-less-znumtheory.rst
@@ -1,0 +1,7 @@
+- `Zdivisibility.v`
+
+  + Refactored theory of integer divisibility including primality and
+    coprimality. This file is intended to replace `Znumtheory`
+    (`#136 <https://github.com/coq/stdlib/pull/136>`_,
+    by Andres Erbsen).
+

--- a/doc/changelog/05-deprecated/136-less-znumtheory.rst
+++ b/doc/changelog/05-deprecated/136-less-znumtheory.rst
@@ -1,0 +1,7 @@
+- in `Znumtheory.v`
+
+  + Deprecated most definitions in favor of `Zdivisibility.v` or appropriate
+    established files
+    (`#136 <https://github.com/coq/stdlib/pull/136>`_,
+    by Andres Erbsen).
+

--- a/doc/stdlib/depends.dot
+++ b/doc/stdlib/depends.dot
@@ -15,12 +15,11 @@ digraph stdlib_deps {
 	strings -> arith;
 	reals -> qarith;
 	reals -> vectors;
-	reals -> lqa;
 	reals -> "classical-logic";
 	reals -> nsatz;
 	"arith-base" -> structures;
 	zarith -> lia;
-	qarith -> field;
+	qarith -> lqa;
 	positive -> "arith-base";
 	narith -> ring;
 	ring -> lists;
@@ -49,8 +48,8 @@ digraph stdlib_deps {
 	"primitive-string" -> "orders-ex";
 	vectors -> lists;
 	field -> zarith;
-	field -> "qarith-base";
 	lqa -> field;
+	lqa -> "qarith-base";
 	"qarith-base" -> ring;
 	"classical-logic" -> arith;
 	nsatz -> zarith;

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -262,6 +262,7 @@ through the <tt>From Stdlib Require Import</tt> command.</p>
     theories/ZArith/Zpow_def.v
     theories/ZArith/Zdiv.v
     theories/ZArith/Znumtheory.v
+    theories/ZArith/Zdivisibility.v
   </dd>
 
   <dt> <a name="arith"></a><b>Arith</b>:

--- a/theories/All/All.v
+++ b/theories/All/All.v
@@ -107,6 +107,7 @@ From Stdlib Require Export ZArith.Zbitwise.
 From Stdlib Require Export ZArith.Zbool.
 From Stdlib Require Export ZArith.Zcompare.
 From Stdlib Require Export ZArith.Zcomplements.
+From Stdlib Require Export ZArith.Zdivisibility.
 From Stdlib Require Export ZArith.Zdiv.
 From Stdlib Require Export ZArith.Zdiv_facts.
 From Stdlib Require Export ZArith.ZModOffset.

--- a/theories/Make.field
+++ b/theories/Make.field
@@ -1,12 +1,5 @@
-QArith/_Field/Qfield.v
-QArith/_Field/Qround.v
-QArith/_Field/Qring.v
-QArith/_Field/Qpower.v
-QArith/_Field/Qcanon.v
 setoid_ring/_Field/Field_theory.v
 setoid_ring/_Field/Field_tac.v
-setoid_ring/_Field/Rings_Q.v
 setoid_ring/_Field/Field.v
 
--Q QArith/_Field Stdlib.QArith
 -Q setoid_ring/_Field Stdlib.setoid_ring

--- a/theories/Make.lqa
+++ b/theories/Make.lqa
@@ -1,5 +1,10 @@
 micromega/_Lqa/QMicromega.v
 micromega/_Lqa/Lqa.v
 micromega/_Lqa/DeclConstant.v
+QArith/_Lqa/Qfield.v
+QArith/_Lqa/Qring.v
+setoid_ring/_QArith/Rings_Q.v
 
 -Q micromega/_Lqa Stdlib.micromega
+-Q QArith/_Lqa Stdlib.QArith
+-Q setoid_ring/_QArith Stdlib.setoid_ring

--- a/theories/Make.qarith
+++ b/theories/Make.qarith
@@ -1,6 +1,9 @@
 QArith/_All/Qcabs.v
+QArith/_All/Qround.v
 QArith/_All/Qabs.v
 QArith/_All/QArith.v
+QArith/_All/Qpower.v
+QArith/_All/Qcanon.v
 Numbers/_QArith/DecimalQ.v
 Numbers/_QArith/HexadecimalQ.v
 

--- a/theories/Make.ring
+++ b/theories/Make.ring
@@ -1,5 +1,4 @@
 ZArith/_Ring/Zpow_def.v
-ZArith/_Ring/Znumtheory.v
 ZArith/_Ring/Zcomplements.v
 ZArith/_Ring/Zdiv.v
 setoid_ring/_Ring/Ncring_polynom.v

--- a/theories/Make.zarith
+++ b/theories/Make.zarith
@@ -8,6 +8,8 @@ ZArith/_All/Zwf.v
 ZArith/_All/ZArith.v
 ZArith/_All/Zbitwise.v
 ZArith/_All/ZModOffset.v
+ZArith/_All/Zdivisibility.v
+ZArith/_All/Znumtheory.v
 Numbers/Integer/Binary/ZBinary.v
 Numbers/Integer/NatPairs/ZNatPairs.v
 Numbers/_ZArith/DecimalN.v

--- a/theories/Numbers/Cyclic/Int63/Sint63.v
+++ b/theories/Numbers/Cyclic/Int63/Sint63.v
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 From Stdlib Require Import ZArith.
-Import Znumtheory.
+Local Open Scope Z_scope.
 From Stdlib Require Export Uint63 Sint63Axioms.
 From Stdlib Require Import Lia.
 

--- a/theories/Numbers/Cyclic/Int63/Uint63.v
+++ b/theories/Numbers/Cyclic/Int63/Uint63.v
@@ -543,10 +543,7 @@ Lemma eqm_sub x y : x ≡ y → x - y ≡ 0.
 Proof. intros h; unfold eqm; rewrite Zminus_mod, h, Z.sub_diag; reflexivity. Qed.
 
 Lemma eqmE x y : x ≡ y → ∃ k, x - y = k * wB.
-Proof.
-  intros h.
-  exact (Zmod_divide (x - y) wB (λ e, let 'eq_refl := e in I) (eqm_sub _ _ h)).
-Qed.
+Proof. intros h%Z.cong_iff_ex; trivial. Qed.
 
 Lemma eqm_subE x y : x ≡ y ↔ x - y ≡ 0.
 Proof.
@@ -963,11 +960,13 @@ Proof.
        assert (F2: 0 < wB) by (apply refl_equal).
        assert (F3: φ (bit x 0 + bit y 0) mod 2 = φ (bit x 0 || bit y 0) mod 2). {
          apply trans_equal with ((φ ((x>>1 + y>>1) << 1) + φ (bit x 0 + bit y 0)) mod 2).
-         - rewrite lsl_spec, Zplus_mod, <-Zmod_div_mod; auto with zarith.
+         - rewrite lsl_spec, Zplus_mod, Z.mod_mod_divide; auto with zarith.
            rewrite Z.pow_1_r, Z_mod_mult, Zplus_0_l, Zmod_mod; auto with zarith.
-         - rewrite (Zmod_div_mod 2 wB), <-add_spec, Heq; auto with zarith.
-           rewrite add_spec, <-Zmod_div_mod; auto with zarith.
-           rewrite lsl_spec, Zplus_mod, <-Zmod_div_mod; auto with zarith.
+         - assert (forall a, a mod 2 = (a mod wB) mod 2) as ->.
+           { intros. rewrite Z.mod_mod_divide; trivial. }
+           rewrite <-add_spec, Heq; auto with zarith.
+           rewrite add_spec, Z.mod_mod_divide; auto with zarith.
+           rewrite lsl_spec, Zplus_mod, Z.mod_mod_divide; auto with zarith.
            rewrite Z.pow_1_r, Z_mod_mult, Zplus_0_l, Zmod_mod; auto with zarith.
        }
        generalize F3; do 2 case bit; try discriminate; auto.

--- a/theories/QArith/Qabs.v
+++ b/theories/QArith/Qabs.v
@@ -88,7 +88,7 @@ intros [xn xd] [yn yd].
 unfold Qplus.
 unfold Qle.
 simpl.
-apply Z.mul_le_mono_nonneg_r;auto with *.
+apply Z.mul_le_mono_nonneg_r; auto using Pos2Z.is_nonneg.
 change (Zpos yd)%Z with (Z.abs (Zpos yd)).
 change (Zpos xd)%Z with (Z.abs (Zpos xd)).
 repeat rewrite <- Z.abs_mul.

--- a/theories/QArith/Qcanon.v
+++ b/theories/QArith/Qcanon.v
@@ -10,7 +10,6 @@
 
 From Stdlib Require Import Field.
 From Stdlib Require Import QArith_base Qreduction.
-From Stdlib Require Import Znumtheory.
 From Stdlib Require Import Eqdep_dec.
 
 (** [Qc] : A canonical representation of rational numbers.

--- a/theories/QArith/Qpower.v
+++ b/theories/QArith/Qpower.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-From Stdlib Require Import Zpow_facts Qfield Qreduction.
+From Stdlib Require Import Qfield Qreduction.
 
 (** * Properties of Qpower_positive *)
 
@@ -438,7 +438,7 @@ induction n using Pos.peano_ind.
   ring.
 - rewrite Pos2Z.inj_succ.
   unfold Z.succ.
-  rewrite Zpower_exp; auto with *; try discriminate.
+  rewrite Z.pow_add_r; auto with *; try discriminate.
   rewrite Qpower_plus' by discriminate.
   rewrite <- IHn by discriminate.
   replace (a^Zpos n*a^1)%Z with (a^Zpos n*a)%Z by ring.
@@ -468,8 +468,8 @@ Proof.
   intros q.
   destruct (Qarchimedean q) as [pexp Hpexp].
   exists (Pos.size pexp).
-  pose proof Pos.size_gt pexp as H1.
-  unfold Qlt in *. cbn in *; Zify.zify.
-  apply (Z.mul_lt_mono_pos_r (QDen q)) in H1; [|assumption].
-  apply (Z.lt_trans _ _ _ Hpexp H1).
+  cbv [Qlt] in *; cbn [Qnum Qden] in *.
+  etransitivity; [exact Hpexp|].
+  rewrite <-Z.mul_lt_mono_pos_r by reflexivity.
+  apply Pos.size_gt.
 Qed.

--- a/theories/QArith/Qreduction.v
+++ b/theories/QArith/Qreduction.v
@@ -11,10 +11,11 @@
 (** Normalisation functions for rational numbers. *)
 
 From Stdlib Require Export QArith_base.
-From Stdlib Require Import Znumtheory.
 
 Notation Z2P := Z.to_pos (only parsing).
 Notation Z2P_correct := Z2Pos.id (only parsing).
+
+Local Coercion Z.pos : positive >-> Z.
 
 (** Simplification of fractions using [Z.gcd].
   This version can compute within Coq. *)
@@ -40,60 +41,37 @@ Proof.
     Close Scope Z_scope.
 Qed.
 
+Lemma Qeq_Qred_iff q q' : Qred q == Qred q' <-> q == q'.
+Proof. rewrite 2Qred_correct; reflexivity. Qed.
+
+Lemma gcd_Qred q : Z.gcd (Qnum (Qred q)) (Qden (Qred q)) = 1%Z.
+Proof.
+  case q as [a b]; cbv [Qred Qnum Qden].
+  pose proof Z.ggcd_correct_divisors a b as Hg.
+  pose proof Z.ggcd_gcd a b as Hgg.
+  destruct (Z.ggcd a b) as (g&a'&b'); cbn [fst snd] in *; subst g; case Hg as [Ha Hb].
+  assert (Z.gcd a b <> 0)%Z by (rewrite Z.gcd_eq_0; intros []; discriminate).
+
+  erewrite <-(Z.gcd_div_gcd a b); trivial; trivial.
+  rewrite Ha, Z.mul_comm, Z.div_mul at 1; trivial.
+  rewrite Hb, Z.mul_comm, Z.div_mul at 1; trivial.
+  rewrite Z2Pos.id; trivial.
+  eapply Z.mul_pos_cancel_l; try rewrite <-Hb; trivial using Pos2Z.is_pos.
+  pose proof Z.gcd_nonneg a b as HH; apply Z.le_lteq in HH; intuition congruence.
+Qed.
+
 Lemma Qred_complete : forall p q,  p==q -> Qred p = Qred q.
 Proof.
-  intros (a,b) (c,d).
-  unfold Qred, Qeq in *; simpl in *.
-  Open Scope Z_scope.
-  intros H.
-  generalize (Z.ggcd_gcd a (Zpos b)) (Zgcd_is_gcd a (Zpos b))
-    (Z.gcd_nonneg a (Zpos b)) (Z.ggcd_correct_divisors a (Zpos b)).
-  destruct (Z.ggcd a (Zpos b)) as (g,(aa,bb)).
-  simpl. intros <- Hg1 Hg2 (Hg3,Hg4).
-  assert (Hg0 : g <> 0) by (intro; now subst g).
-  generalize (Z.ggcd_gcd c (Zpos d)) (Zgcd_is_gcd c (Zpos d))
-    (Z.gcd_nonneg c (Zpos d)) (Z.ggcd_correct_divisors c (Zpos d)).
-  destruct (Z.ggcd c (Zpos d)) as (g',(cc,dd)).
-  simpl. intros <- Hg'1 Hg'2 (Hg'3,Hg'4).
-  assert (Hg'0 : g' <> 0) by (intro; now subst g').
+  setoid_rewrite <-Qeq_Qred_iff.
+  intros a b; specialize (gcd_Qred a); specialize (gcd_Qred b).
+  destruct (Qred a) as [p q]; destruct (Qred b) as [p' q'].
+  cbv [Qred Qeq Qnum Qden]; intros H H' Hcross.
 
-  elim (rel_prime_cross_prod aa bb cc dd).
-  - congruence.
-  - (*rel_prime*)
-    constructor.
-    * exists aa; auto using Z.mul_1_r.
-    * exists bb; auto using Z.mul_1_r.
-    * intros x Ha Hb.
-      destruct Hg1 as (Hg11,Hg12,Hg13).
-      destruct (Hg13 (g*x)) as (x',Hx).
-      { rewrite Hg3.
-        destruct Ha as (xa,Hxa); exists xa; rewrite Hxa; ring. }
-      { rewrite Hg4.
-        destruct Hb as (xb,Hxb); exists xb; rewrite Hxb; ring. }
-      exists x'.
-      apply Z.mul_reg_l with g; auto. rewrite Hx at 1; ring.
-  - (* rel_prime *)
-    constructor.
-    * exists cc; auto using Z.mul_1_r.
-    * exists dd; auto using Z.mul_1_r.
-    * intros x Hc Hd.
-      inversion Hg'1 as (Hg'11,Hg'12,Hg'13).
-      destruct (Hg'13 (g'*x)) as (x',Hx).
-      { rewrite Hg'3.
-        destruct Hc as (xc,Hxc); exists xc; rewrite Hxc; ring. }
-      { rewrite Hg'4.
-        destruct Hd as (xd,Hxd); exists xd; rewrite Hxd; ring. }
-      exists x'.
-      apply Z.mul_reg_l with g'; auto. rewrite Hx at 1; ring.
-  - apply Z.lt_gt.
-    rewrite <- (Z.mul_pos_cancel_l g); [ now rewrite <- Hg4 |  apply Z.le_neq; intuition ].
-  - apply Z.lt_gt.
-    rewrite <- (Z.mul_pos_cancel_l g'); [now rewrite <- Hg'4 | apply Z.le_neq; intuition ].
-  - apply Z.mul_reg_l with (g*g').
-    * rewrite Z.mul_eq_0. now destruct 1.
-    * rewrite Z.mul_shuffle1, <- Hg3, <- Hg'4.
-      now rewrite Z.mul_shuffle1, <- Hg'3, <- Hg4, H, Z.mul_comm.
-  Close Scope Z_scope.
+  pose proof Z.gauss q' p' q ltac:(exists p; ring [Hcross]) ltac:(rewrite Z.gcd_comm; trivial).
+  pose proof Z.gauss q p q' ltac:(exists p'; ring [Hcross]) ltac:(rewrite Z.gcd_comm; trivial).
+  pose proof Pos2Z.is_nonneg.
+  pose proof Z.divide_antisym_nonneg q q' ltac:(trivial) ltac:(trivial) ltac:(trivial) ltac:(trivial) as q'q.
+  injection q'q as <-; f_equal. eapply Z.mul_cancel_r with (p:=q); trivial. inversion 1.
 Qed.
 
 Lemma Qred_eq_iff q q' : Qred q = Qred q' <-> q == q'.

--- a/theories/QArith/Qround.v
+++ b/theories/QArith/Qround.v
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 From Stdlib Require Import QArith_base.
-From Stdlib Require Import Zhints Zdiv.
+From Stdlib Require Import Zdiv.
 
 (************)
 
@@ -78,7 +78,7 @@ replace (n / Zpos d * Zpos d + Zpos d)%Z with
   ((Zpos d * (n / Zpos d) + n mod Zpos  d) + Zpos  d - n mod Zpos d)%Z by ring.
 rewrite <- Z_div_mod_eq_full.
 rewrite <- Z.lt_add_lt_sub_r.
-destruct (Z_mod_lt n (Zpos d)); auto with *.
+apply Z.add_lt_mono_l, Z.mod_pos_bound, eq_refl.
 Qed.
 
 #[global]
@@ -92,7 +92,7 @@ replace (- Qfloor (- x) - 1)%Z with (-(Qfloor (-x) + 1))%Z by ring.
 change ((- (Qfloor (- x) + 1))%Z:Q) with (-(Qfloor (- x) + 1)%Z).
 apply Qlt_le_trans with (- - x); auto with *.
 rewrite Qopp_involutive.
-auto with *.
+apply Qle_refl.
 Qed.
 
 #[global]
@@ -106,7 +106,7 @@ simpl in *.
 rewrite <- (Zdiv_mult_cancel_r xn (Zpos xd) (Zpos yd)); auto with *.
 rewrite <- (Zdiv_mult_cancel_r yn (Zpos yd) (Zpos xd)); auto with *.
 rewrite (Z.mul_comm (Zpos yd) (Zpos xd)).
-apply Z_div_le; auto with *.
+apply Z.div_le_mono, Hxy; apply eq_refl.
 Qed.
 
 #[global]

--- a/theories/Reals/Nsatz.v
+++ b/theories/Reals/Nsatz.v
@@ -22,7 +22,6 @@ From Stdlib Require Import List.
 From Stdlib Require Import Setoid.
 From Stdlib Require Import BinPos.
 From Stdlib Require Import BinList.
-From Stdlib Require Import Znumtheory.
 From Stdlib Require Export Morphisms Setoid Bool.
 From Stdlib Require Export Algebra_syntax.
 From Stdlib Require Export Ncring.

--- a/theories/ZArith/ZArith.v
+++ b/theories/ZArith/ZArith.v
@@ -53,3 +53,6 @@ From Stdlib Require Export Zbitwise.
 From Stdlib Require Export ZModOffset.
 
 Export ZArithRing.
+
+(* This compat Require is deprecated since 9.1 *)
+From Stdlib Require Znumtheory.

--- a/theories/ZArith/ZArith.v
+++ b/theories/ZArith/ZArith.v
@@ -47,6 +47,7 @@ From Stdlib Require Export ZArith_hints.
 From Stdlib Require Export Zcomplements.
 From Stdlib Require Export Zpower.
 From Stdlib Require Export Zdiv.
+From Stdlib Require Export Zdivisibility.
 From Stdlib Require Export Zdiv_facts.
 From Stdlib Require Export Zbitwise.
 From Stdlib Require Export ZModOffset.

--- a/theories/ZArith/ZModOffset.v
+++ b/theories/ZArith/ZModOffset.v
@@ -1,4 +1,4 @@
-Require Import BinInt Zdiv Zdiv_facts Znumtheory PreOmega Lia Wf_Z ZArith_dec.
+Require Import BinInt Zdiv Zdiv_facts PreOmega Lia Wf_Z ZArith_dec.
 Local Open Scope Z_scope.
 
 Module Z.

--- a/theories/ZArith/Zdiv_facts.v
+++ b/theories/ZArith/Zdiv_facts.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-From Stdlib Require Import BinInt Zdiv Znumtheory PreOmega Lia.
+From Stdlib Require Import BinInt Zdiv PreOmega Lia.
 Local Open Scope Z_scope.
 
 Module Z.

--- a/theories/ZArith/Zdivisibility.v
+++ b/theories/ZArith/Zdivisibility.v
@@ -1,0 +1,142 @@
+From Stdlib Require Import BinInt Wf_Z ZArithRing Zdiv Lia.
+
+Module Z.
+Local Open Scope Z_scope.
+
+Lemma mod0_divide : forall a b, (b | a) -> a mod b = 0.
+Proof. intros a b (c,->); apply Z_mod_mult. Qed.
+
+Lemma absle_divide a b : (a | b) -> b <> 0 -> Z.abs a <= Z.abs b.
+Proof.
+ intros H Hb.
+ rewrite <- Z.divide_abs_l, <- Z.divide_abs_r in H.
+ apply Z.abs_pos in Hb.
+ now apply Z.divide_pos_le.
+Qed.
+
+Lemma BoolSpec_divide_nz a b (H : a <> 0) : BoolSpec (Z.divide a b) (~ Z.divide a b) (b mod a =? 0).
+Proof. case Z.eqb_spec; constructor; rewrite <-Z.mod_divide; trivial. Qed.
+
+Lemma BoolSpec_divide a b : BoolSpec (Z.divide a b) (~ Z.divide a b) ((b =? 0) || negb (a =? 0) && (b mod a =? 0))%bool.
+Proof.
+  case Z.eqb_spec; rewrite ?Bool.orb_true_l, ?Bool.orb_false_l; intros; subst.
+  { constructor. apply Z.divide_0_r. }
+  case Z.eqb_spec; rewrite ?Bool.orb_true_l, ?Bool.orb_false_l; intros; subst.
+  { constructor. intros ?%Z.divide_0_l; contradiction. }
+  apply BoolSpec_divide_nz; trivial.
+Qed.
+
+
+Definition coprime (a b:Z) : Prop := Z.gcd a b = 1.
+
+Lemma BoolSpec_coprime a b : BoolSpec (Z.coprime a b) (~ Z.coprime a b) (Z.gcd a b =? 1).
+Proof. case Z.eqb_spec; constructor; assumption. Qed.
+
+Lemma Bezout_coprime_iff a b : Z.coprime a b <-> Z.Bezout a b 1.
+Proof. split; try apply Z.gcd_bezout; try apply Z.bezout_1_gcd. Qed.
+
+Definition Bezout_coprime a b := proj1 (Bezout_coprime_iff a b).
+Definition coprime_Bezout a b := proj2 (Bezout_coprime_iff a b).
+
+#[global] Instance Symmetric_coprime : RelationClasses.Symmetric coprime.
+Proof. cbv [coprime]; intros ? ? ?; rewrite Z.gcd_comm; trivial. Qed.
+
+Lemma coprime_0_l_iff z : coprime 0 z <-> Z.abs z = 1.
+Proof. cbv [coprime]. rewrite Z.gcd_0_l. reflexivity. Qed.
+
+Lemma coprime_0_r_iff z : coprime z 0 <-> Z.abs z = 1.
+Proof. cbv [coprime]. rewrite Z.gcd_0_r. reflexivity. Qed.
+
+Lemma coprime_1_l z : coprime 1 z. Proof. apply Z.gcd_1_l. Qed.
+
+Lemma coprime_1_r z : coprime z 1. Proof. apply Z.gcd_1_r. Qed.
+
+Lemma coprime_opp_l a b : coprime (- a) b <-> coprime a b.
+Proof. cbv [coprime]. rewrite Z.gcd_opp_l. reflexivity. Qed.
+
+Lemma coprime_opp_r a b : coprime a (- b) <-> coprime a b.
+Proof. cbv [coprime]. rewrite Z.gcd_opp_r. reflexivity. Qed.
+
+Lemma coprime_mod_l_iff a b : coprime (a mod b) b <-> coprime a b.
+Proof. cbv [coprime]. rewrite Z.gcd_mod_l; reflexivity. Qed.
+
+Lemma coprime_mod_r_iff a b : coprime a (b mod a) <-> coprime a b.
+Proof. cbv [coprime]. rewrite Z.gcd_mod_r; reflexivity. Qed.
+
+Lemma coprime_mul_r a b c : coprime a b -> coprime a c -> coprime a (b * c).
+Proof.
+  setoid_rewrite Bezout_coprime_iff.
+  intros (u&v&H) (u0&v0&H0); exists (u*u0*a + v0*c*u + u0*v* b), (v*v0).
+  rewrite <- H, <-Z.mul_1_r, <- H0; ring.
+Qed.
+
+Lemma coprime_mul_l a b c : coprime a c -> coprime b c -> coprime (a * b) c.
+Proof. symmetry. apply coprime_mul_r; symmetry; trivial. Qed.
+
+Lemma coprime_pow_r a b n : 0 <= n -> coprime a b -> coprime a (b ^ n).
+Proof.
+  intros Hn H; pattern n; apply natlike_ind; auto using coprime_1_r; intros.
+  rewrite Z.pow_succ_r; auto using coprime_mul_r.
+Qed.
+
+Lemma coprime_pow_l a b n : 0 <= n -> coprime a b -> coprime (a ^ n) b.
+Proof. symmetry. apply coprime_pow_r; try symmetry; trivial. Qed.
+
+
+Definition prime p := 1 < p /\ forall n, 1 < n < p -> ~ (n|p).
+
+Lemma not_prime_0 : not (prime 0).
+Proof. intros []. lia. Qed.
+
+Lemma not_prime_1 : not (prime 1).
+Proof. intros []. lia. Qed.
+
+Lemma prime_2 : prime 2.
+Proof. split. lia. intros; intros []; nia. Qed.
+
+Lemma prime_3 : prime 3.
+Proof. split. lia. intros; intros []. assert (n = 2); nia. Qed.
+
+Lemma prime_ge_2 p : prime p ->  2 <= p.
+Proof. cbv [prime]. lia. Qed.
+
+Section extended_euclid_algorithm.
+Variables a b : Z.
+
+Local Lemma extgcd_rec_helper r1 r2 q :
+  Z.gcd r1 r2 = Z.gcd a b -> Z.gcd (r2 - q * r1) r1 = Z.gcd a b.
+Proof.
+  intros H; rewrite <-H, Z.gcd_comm.
+  rewrite <-(Z.gcd_add_mult_diag_r r1 r2 (-q)). f_equal; ring.
+Qed.
+
+Let f := S(S(Z.to_nat(Z.log2_up(Z.log2_up(Z.abs(a*b)))))). (* log2(fuel) *)
+
+Local Definition extgcd_rec : forall r1 u1 v1 r2 u2 v2,
+  (True -> 0 <= r1 /\ 0 <= r2 /\ r1 = u1 * a + v1 * b /\ r2 = u2 * a + v2 * b /\
+      Z.gcd r1 r2 = Z.gcd a b)
+   -> { '(u, v, d) | True -> u * a + v * b = d /\ d = Z.gcd a b}.
+Proof.
+  refine (Fix (Acc_intro_generator f (Z.lt_wf 0)) _ (fun r1 rec u1 v1  r2 u2 v2 H =>
+    if Z.eq_dec r1 0
+    then exist (fun '(u, v, d) => _) (u2, v2, r2) (fun _ => _)
+    else let q := r2 / r1 in
+         rec (r2 - q * r1) _ (u2 - q * u1) (v2 - q * v1) r1 u1 v1 (fun _ => _))).
+  all : abstract (intuition (solve
+    [ subst; rewrite ?Z.gcd_0_l_nonneg in *; auto using extgcd_rec_helper; ring
+    | subst q; rewrite <-Zmod_eq_full by trivial;
+      apply Z.mod_pos_bound, Z.le_neq; intuition congruence ])).
+Defined.
+
+Definition extgcd : Z*Z*Z.
+Proof.
+  refine (proj1_sig (extgcd_rec (Z.abs a) (Z.sgn a) 0 (Z.abs b) 0 (Z.sgn b) _)).
+  abstract (intuition (trivial using Z.abs_nonneg;
+    rewrite ?Z.gcd_abs_r, ?Z.gcd_abs_l, <-?Z.sgn_abs; ring)).
+Defined.
+
+Lemma extgcd_correct [u v d] : extgcd = (u, v, d) -> u * a + v * b = d /\ d = Z.gcd a b.
+Proof. cbv [extgcd proj1_sig]. case extgcd_rec as (([],?),?). intuition congruence. Qed.
+End extended_euclid_algorithm.
+
+End Z.

--- a/theories/ZArith/Zgcd_alt.v
+++ b/theories/ZArith/Zgcd_alt.v
@@ -73,6 +73,17 @@ Open Scope Z_scope.
 
  (** 1) We prove a weaker & easier bound. *)
 
+ Local Lemma Private_Zis_gcd_for_euclid2 :
+  forall b d q r:Z, Zis_gcd r b d -> Zis_gcd b (b * q + r) d.
+ Proof.
+   intros b d q r; destruct 1 as [? ? H]; constructor;
+     intuition auto using Z.divide_add_r, Z.divide_mul_l.
+   apply H; auto.
+   replace r with (b * q + r - b * q).
+   - auto with zarith.
+   - ring.
+ Qed.
+
  Lemma Zgcdn_linear_bound : forall n a b,
    Z.abs a < Z.of_nat n -> Zis_gcd a b (Zgcdn n a b).
  Proof.
@@ -89,9 +100,9 @@ Open Scope Z_scope.
        assert (IH:=IHn r (Zpos p) H2); clear IHn;
        simpl in IH |- *;
        rewrite H0.
-     + apply Zis_gcd_for_euclid2; auto.
+     + apply Private_Zis_gcd_for_euclid2; auto.
      + apply Zis_gcd_minus; apply Zis_gcd_sym.
-       apply Zis_gcd_for_euclid2; auto.
+       apply Private_Zis_gcd_for_euclid2; auto.
  Qed.
 
  (** 2) For Euclid's algorithm, the worst-case situation corresponds
@@ -155,7 +166,7 @@ Open Scope Z_scope.
        * assert (EQ' : r = Zpos a * (-q) + b) by (rewrite EQ; ring).
          rewrite EQ' at 1.
          apply Zis_gcd_sym.
-         apply Zis_gcd_for_euclid2; auto.
+         apply Private_Zis_gcd_for_euclid2; auto.
          apply Zis_gcd_sym; auto.
        * split.
          -- auto.
@@ -246,7 +257,7 @@ Open Scope Z_scope.
   generalize (Z_div_mod b (Zpos a) (eq_refl Gt)).
   destruct (Z.div_eucl b (Zpos a)) as (q,r).
   intros (->,(H1,H2)) H3.
-  apply Zis_gcd_for_euclid2.
+  apply Private_Zis_gcd_for_euclid2.
   Z.le_elim H1.
   + apply Zgcdn_ok_before_fibonacci; auto.
     apply Z.lt_le_trans with (fibonacci (S m));

--- a/theories/ZArith/Znumtheory.v
+++ b/theories/ZArith/Znumtheory.v
@@ -13,7 +13,9 @@ From Stdlib Require Import ZArith_base.
 From Stdlib Require Import ZArithRing.
 From Stdlib Require Import Zcomplements.
 From Stdlib Require Import Zdiv.
+From Stdlib Require Import Zdivisibility.
 From Stdlib Require Import Wf_nat.
+From Stdlib Require Import Lia Cring Ncring_tac.
 
 (** For compatibility reasons, this Open Scope isn't local as it should *)
 
@@ -35,36 +37,53 @@ Local Ltac Tauto.intuition_solver ::= auto with zarith.
 
 (** Its former constructor is now a pseudo-constructor. *)
 
+#[deprecated(use=ex_intro, since="9.1")]
 Definition Zdivide_intro a b q (H:b=q*a) : Z.divide a b := ex_intro _ q H.
 
 (** Results concerning divisibility*)
 
+#[deprecated(use=Z.divide_1_l, since="9.1")]
 Notation Zone_divide := Z.divide_1_l (only parsing).
+#[deprecated(use=Z.divide_0_r, since="9.1")]
 Notation Zdivide_0 := Z.divide_0_r (only parsing).
+#[deprecated(use=Z.mul_divide_mono_l, since="9.1")]
 Notation Zmult_divide_compat_l := Z.mul_divide_mono_l (only parsing).
+#[deprecated(use=Z.mul_divide_mono_r, since="9.1")]
 Notation Zmult_divide_compat_r := Z.mul_divide_mono_r (only parsing).
+#[deprecated(use=Z.divide_add_r, since="9.1")]
 Notation Zdivide_plus_r := Z.divide_add_r (only parsing).
+#[deprecated(use=Z.divide_sub_r, since="9.1")]
 Notation Zdivide_minus_l := Z.divide_sub_r (only parsing).
+#[deprecated(use=Z.divide_mul_l, since="9.1")]
 Notation Zdivide_mult_l := Z.divide_mul_l (only parsing).
+#[deprecated(use=Z.divide_mul_r, since="9.1")]
 Notation Zdivide_mult_r := Z.divide_mul_r (only parsing).
+#[deprecated(use=Z.divide_factor_l, since="9.1")]
 Notation Zdivide_factor_r := Z.divide_factor_l (only parsing).
+#[deprecated(use=Z.divide_factor_r, since="9.1")]
 Notation Zdivide_factor_l := Z.divide_factor_r (only parsing).
 
+#[deprecated(use=Z.divide_opp_r, since="9.1")]
 Lemma Zdivide_opp_r a b : (a | b) -> (a | - b).
 Proof. apply Z.divide_opp_r. Qed.
 
+#[deprecated(use=Z.divide_opp_r, since="9.1")]
 Lemma Zdivide_opp_r_rev a b : (a | - b) -> (a | b).
 Proof. apply Z.divide_opp_r. Qed.
 
+#[deprecated(use=Z.divide_opp_l, since="9.1")]
 Lemma Zdivide_opp_l a b : (a | b) -> (- a | b).
 Proof. apply Z.divide_opp_l. Qed.
 
+#[deprecated(use=Z.divide_opp_l, since="9.1")]
 Lemma Zdivide_opp_l_rev a b : (- a | b) -> (a | b).
 Proof. apply Z.divide_opp_l. Qed.
 
+#[deprecated(use=Z.divide_abs_l, since="9.1")]
 Theorem Zdivide_Zabs_l a b : (Z.abs a | b) -> (a | b).
 Proof. apply Z.divide_abs_l. Qed.
 
+#[deprecated(use=Z.divide_abs_l, since="9.1")]
 Theorem Zdivide_Zabs_inv_l a b : (a | b) -> (Z.abs a | b).
 Proof. apply Z.divide_abs_l. Qed.
 
@@ -79,6 +98,7 @@ Hint Resolve Z.divide_add_r Zdivide_opp_r Zdivide_opp_r_rev Zdivide_opp_l
 
 (** Auxiliary result. *)
 
+#[deprecated(use=Z.eq_mul_1_nonneg, since="9.1")]
 Lemma Zmult_one x y : x >= 0 -> x * y = 1 -> x = 1.
 Proof.
  Z.swap_greater. apply Z.eq_mul_1_nonneg.
@@ -86,32 +106,30 @@ Qed.
 
 (** Only [1] and [-1] divide [1]. *)
 
+#[deprecated(use=Z.divide_1_r, since="9.1")]
 Notation Zdivide_1 := Z.divide_1_r (only parsing).
 
 (** If [a] divides [b] and [b<>0] then [|a| <= |b|]. *)
 
-Lemma Zdivide_bounds a b : (a | b) -> b <> 0 -> Z.abs a <= Z.abs b.
-Proof.
- intros H Hb.
- rewrite <- Z.divide_abs_l, <- Z.divide_abs_r in H.
- apply Z.abs_pos in Hb.
- now apply Z.divide_pos_le.
-Qed.
+#[deprecated(use=Z.absle_divide, since="9.1")]
+Notation Zdivide_bounds := Z.absle_divide (only parsing).
 
 (** [Z.divide] can be expressed using [Z.modulo]. *)
 
+#[deprecated(use=Z.mod0_divide, since="9.1")]
 Lemma Zmod_divide : forall a b, b<>0 -> a mod b = 0 -> (b | a).
 Proof.
  apply Z.mod_divide.
 Qed.
 
+#[deprecated(use=Z.mod0_divide, since="9.1")]
 Lemma Zdivide_mod : forall a b, (b | a) -> a mod b = 0.
 Proof.
  intros a b (c,->); apply Z_mod_mult.
 Qed.
 
 (** [Z.divide] is hence decidable *)
-
+#[deprecated(use=Z.BoolSpec_divide, since="9.1")]
 Lemma Zdivide_dec a b : {(a | b)} + {~ (a | b)}.
 Proof.
  destruct (Z.eq_dec a 0) as [Ha|Ha].
@@ -123,6 +141,7 @@ Proof.
    + right. now rewrite <- Z.mod_divide.
 Defined.
 
+#[deprecated(use=Z.lt_neq, since="9.1")]
 Lemma Z_lt_neq {x y: Z} : x < y -> y <> x.
 Proof. auto using Z.lt_neq, Z.neq_sym. Qed.
 
@@ -142,6 +161,7 @@ Proof.
  + auto with zarith.
 Qed.
 
+#[deprecated(use=Z.divide_pos_le, since="9.1")]
 Theorem Zdivide_le: forall a b : Z,
  0 <= a -> 0 < b -> (a | b) ->  a <= b.
 Proof.
@@ -159,6 +179,7 @@ Proof.
   + now apply Z.div_lt.
 Qed.
 
+#[deprecated(use=Z.mod_mod_divide, since="9.1")]
 Lemma Zmod_div_mod n m a:
  0 < n -> 0 < m -> (n | m) -> a mod n = (a mod m) mod n.
 Proof with auto using Z_lt_neq.
@@ -203,6 +224,7 @@ Inductive Zis_gcd (a b g:Z) : Prop :=
   (forall x, (x | a) -> (x | b) -> (x | g)) ->
   Zis_gcd a b g.
 
+#[deprecated(use=Z.gcd, since="9.1")]
 Lemma Zgcd_is_gcd : forall a b, Zis_gcd a b (Z.gcd a b).
 Proof.
  constructor.
@@ -223,11 +245,13 @@ Proof.
   constructor; auto with zarith.
 Qed.
 
+#[deprecated(use=Z.gcd_1_r, since="9.1")]
 Lemma Zis_gcd_1 : forall a, Zis_gcd a 1 1.
 Proof.
   constructor; auto with zarith.
 Qed.
 
+#[deprecated(use=Z.gcd_diag, since="9.1")]
 Lemma Zis_gcd_refl : forall a, Zis_gcd a a a.
 Proof.
   constructor; auto with zarith.
@@ -238,6 +262,7 @@ Proof.
   induction 1; constructor; intuition.
 Qed.
 
+#[deprecated(note="Z.cd is always non-negative", since="9.1")]
 Lemma Zis_gcd_opp : forall a b d, Zis_gcd a b d -> Zis_gcd b a (- d).
 Proof.
   induction 1; constructor; intuition.
@@ -253,6 +278,7 @@ Qed.
 #[global]
 Hint Resolve Zis_gcd_sym Zis_gcd_0 Zis_gcd_minus Zis_gcd_opp: zarith.
 
+#[deprecated(use=f_equal, note="Use Z.gcd", since="9.1")]
 Theorem Zis_gcd_unique: forall a b c d : Z,
  Zis_gcd a b c -> Zis_gcd a b d ->  c = d \/ c = (- d).
 Proof.
@@ -277,6 +303,7 @@ Qed.
 Notation Zis_gcd_for_euclid := deprecated_Zis_gcd_for_euclid (only parsing).
 
 (* this lemma is still used below and in Zgcd_alt *)
+#[deprecated(since="9.1")]
 Lemma Zis_gcd_for_euclid2 :
   forall b d q r:Z, Zis_gcd r b d -> Zis_gcd b (b * q + r) d.
 Proof.
@@ -287,56 +314,22 @@ Proof.
   - ring.
 Qed.
 
-(** We implement the extended version of Euclid's algorithm,
-    i.e. the one computing Bezout's coefficients as it computes
-    the [gcd]. We follow the algorithm given in Knuth's
-    "Art of Computer Programming", vol 2, page 325. *)
+#[deprecated(use=Z.extgcd, since="9.1")]
+Notation extgcd := Z.extgcd (only parsing).
+
+#[deprecated(use=Z.extgcd_correct, since="9.1")]
+Notation extgcd_correct := Z.extgcd_correct (only parsing).
 
 Section extended_euclid_algorithm.
 
   Variables a b : Z.
-
-  Local Lemma extgcd_rec_helper r1 r2 q :
-    Z.gcd r1 r2 = Z.gcd a b -> Z.gcd (r2 - q * r1) r1 = Z.gcd a b.
-  Proof.
-    intros H; rewrite <-H, Z.gcd_comm.
-    rewrite <-(Z.gcd_add_mult_diag_r r1 r2 (-q)). f_equal; ring.
-  Qed.
-
-  Let f := S(S(Z.to_nat(Z.log2_up(Z.log2_up(Z.abs(a*b)))))). (* log2(fuel) *)
-
-  Local Definition extgcd_rec : forall r1 u1 v1 r2 u2 v2,
-    (True -> 0 <= r1 /\ 0 <= r2 /\ r1 = u1 * a + v1 * b /\ r2 = u2 * a + v2 * b /\
-        Z.gcd r1 r2 = Z.gcd a b)
-     -> { '(u, v, d) | True -> u * a + v * b = d /\ d = Z.gcd a b}.
-  Proof.
-    refine (Fix (Acc_intro_generator f (Z.lt_wf 0)) _ (fun r1 rec u1 v1  r2 u2 v2 H =>
-      if Z.eq_dec r1 0
-      then exist (fun '(u, v, d) => _) (u2, v2, r2) (fun _ => _)
-      else let q := r2 / r1 in
-           rec (r2 - q * r1) _ (u2 - q * u1) (v2 - q * v1) r1 u1 v1 (fun _ => _))).
-    all : abstract (intuition (solve
-      [ subst; rewrite ?Z.gcd_0_l_nonneg in *; auto using extgcd_rec_helper; ring
-      | subst q; rewrite <-Zmod_eq_full by trivial;
-        apply Z.mod_pos_bound, Z.le_neq; intuition congruence ])).
-  Defined.
-
-  Definition extgcd : Z*Z*Z.
-  Proof.
-    refine (proj1_sig (extgcd_rec (Z.abs a) (Z.sgn a) 0 (Z.abs b) 0 (Z.sgn b) _)).
-    abstract (intuition (trivial using Z.abs_nonneg;
-      rewrite ?Z.gcd_abs_r, ?Z.gcd_abs_l, <-?Z.sgn_abs; ring)).
-  Defined.
-
-  Lemma extgcd_correct [u v d] : extgcd = (u, v, d) -> u * a + v * b = d /\ d = Z.gcd a b.
-  Proof. cbv [extgcd proj1_sig]. case extgcd_rec as (([],?),?). intuition congruence. Qed.
 
   Inductive deprecated_Euclid : Set :=
     deprecated_Euclid_intro :
     forall u v d:Z, u * a + v * b = d -> Zis_gcd a b d -> deprecated_Euclid.
 
   Lemma deprecated_euclid : deprecated_Euclid.
-  Proof. case extgcd as [[]?] eqn:H; case (extgcd_correct H); esplit; subst; eauto using Zgcd_is_gcd. Qed.
+  Proof. case (extgcd a b) as [[]?] eqn:H; case (Z.extgcd_correct a b H); esplit; subst; eauto using Zgcd_is_gcd. Qed.
 
   Lemma deprecated_euclid_rec :
     forall v3:Z,
@@ -358,6 +351,7 @@ Notation euclid := deprecated_euclid (only parsing).
 #[deprecated(since="8.17", note="Use Coq.ZArith.Znumtheory.extgcd")]
 Notation euclid_rec := deprecated_euclid_rec (only parsing).
 
+#[deprecated(use=Z.gcd_unique, since="9.1")]
 Theorem Zis_gcd_uniqueness_apart_sign :
   forall a b d d':Z, Zis_gcd a b d -> Zis_gcd a b d' -> d = d' \/ d = - d'.
 Proof.
@@ -370,11 +364,16 @@ Qed.
 
 (** * Bezout's coefficients *)
 
-Inductive Bezout (a b d:Z) : Prop :=
-  Bezout_intro : forall u v:Z, u * a + v * b = d -> Bezout a b d.
+Inductive Bezout_deprecated (a b d:Z) : Prop :=
+  Bezout_deprecated_intro : forall u v:Z, u * a + v * b = d -> Bezout_deprecated a b d.
+
+#[deprecated(use=Z.Bezout, since="9.1")]
+Notation Bezout := Bezout_deprecated (only parsing).
+#[deprecated(use=ex_intro, since="9.1")]
+Notation Bezout_intro := Bezout_deprecated_intro (only parsing).
 
 (** Existence of Bezout's coefficients for the [gcd] of [a] and [b] *)
-
+#[deprecated(use=Z.Bezout_coprime_iff, since="9.1")]
 Lemma Zis_gcd_bezout : forall a b d:Z, Zis_gcd a b d -> Bezout a b d.
 Proof.
   intros a b d Hgcd.
@@ -385,6 +384,7 @@ Qed.
 
 (** gcd of [ca] and [cb] is [c gcd(a,b)]. *)
 
+#[deprecated(use=Z.gcd_mul_mono_l, since="9.1")]
 Lemma Zis_gcd_mult :
   forall a b c d:Z, Zis_gcd a b d -> Zis_gcd (c * a) (c * b) (c * d).
 Proof.
@@ -405,14 +405,27 @@ Qed.
 
 Definition rel_prime (a b:Z) : Prop := Zis_gcd a b 1.
 
+Lemma rel_prime_iff_coprime  a b : rel_prime a b <-> Z.coprime a b.
+Proof.
+  symmetry; unfold rel_prime; split; intros H.
+  - rewrite <- H; apply Zgcd_is_gcd.
+  - case (Zis_gcd_unique a b (Z.gcd a b) 1); auto.
+    + apply Zgcd_is_gcd.
+    + intros H2; absurd (0 <= Z.gcd a b); auto with zarith.
+      * rewrite H2; red; auto.
+      * generalize (Z.gcd_nonneg a b); auto with zarith.
+Qed.
+
 (** Bezout's theorem: [a] and [b] are relatively prime if and
     only if there exist [u] and [v] such that [ua+vb = 1]. *)
 
+#[deprecated(use=Z.Bezout_coprime, since="9.1")]
 Lemma rel_prime_bezout : forall a b:Z, rel_prime a b -> Bezout a b 1.
 Proof.
   intros a b; exact (Zis_gcd_bezout a b 1).
 Qed.
 
+#[deprecated(use=Z.coprime_Bezout, since="9.1")]
 Lemma bezout_rel_prime : forall a b:Z, Bezout a b 1 -> rel_prime a b.
 Proof.
   simple induction 1; intros ? ? H0; constructor; auto with zarith.
@@ -422,6 +435,7 @@ Qed.
 (** Gauss's theorem: if [a] divides [bc] and if [a] and [b] are
     relatively prime, then [a] divides [c]. *)
 
+#[deprecated(use=Z.gauss, since="9.1")]
 Theorem Gauss : forall a b c:Z, (a | b * c) -> rel_prime a b -> (a | c).
 Proof.
   intros a b c H H0. elim (rel_prime_bezout a b H0); intros u v H1.
@@ -433,21 +447,12 @@ Qed.
 
 (** If [a] is relatively prime to [b] and [c], then it is to [bc] *)
 
+#[deprecated(use=Z.coprime_mul_r, since="9.1")]
 Lemma rel_prime_mult :
   forall a b c:Z, rel_prime a b -> rel_prime a c -> rel_prime a (b * c).
-Proof.
-  intros a b c Hb Hc.
-  elim (rel_prime_bezout a b Hb); intros u v H.
-  elim (rel_prime_bezout a c Hc); intros u0 v0 H0.
-  apply bezout_rel_prime.
-  apply (Bezout_intro _ _ _
-    (u * u0 * a + v0 * c * u + u0 * v * b) (v * v0)).
-  rewrite <- H.
-  replace (u * a + v * b) with ((u * a + v * b) * 1); [ idtac | ring ].
-  rewrite <- H0.
-  ring.
-Qed.
+Proof. setoid_rewrite rel_prime_iff_coprime; apply Z.coprime_mul_r. Qed.
 
+#[deprecated(note="Consider Z.gcd instead", since="9.1")]
 Lemma rel_prime_cross_prod :
   forall a b c d:Z,
     rel_prime a b ->
@@ -475,6 +480,7 @@ Qed.
 
 (** After factorization by a gcd, the original numbers are relatively prime. *)
 
+#[deprecated(use=Z.gcd_div_gcd, since="9.1")]
 Lemma Zis_gcd_rel_prime :
   forall a b g:Z,
     b > 0 -> g >= 0 -> Zis_gcd a b g -> rel_prime (a / g) (b / g).
@@ -510,6 +516,7 @@ Proof.
       exists x'; auto with zarith.
 Qed.
 
+#[deprecated(use=Z.Symmetric_coprime, since="9.1")]
 Theorem rel_prime_sym: forall a b, rel_prime a b -> rel_prime b a.
 Proof.
   intros a b H; auto with zarith.
@@ -526,6 +533,7 @@ Proof.
   apply Z.divide_mul_r; auto.
 Qed.
 
+#[deprecated(use=Z.coprime_1_l, since="9.1")]
 Theorem rel_prime_1: forall n, rel_prime 1 n.
 Proof.
   intros n; red; apply Zis_gcd_intro; auto.
@@ -533,6 +541,7 @@ Proof.
   - exists n; rewrite Z.mul_1_r; reflexivity.
 Qed.
 
+#[deprecated(use=Z.coprime_0_l_iff, since="9.1")]
 Theorem not_rel_prime_0: forall n, 1 < n -> ~ rel_prime 0 n.
 Proof.
   intros n H H1; absurd (n = 1 \/ n = -1).
@@ -543,6 +552,7 @@ Proof.
     + exists 1; rewrite Z.mul_1_l; reflexivity.
 Qed.
 
+#[deprecated(use=Z.coprime_mod_l_iff, since="9.1")]
 Theorem rel_prime_mod: forall p q, 0 < q ->
  rel_prime p q -> rel_prime (p mod q) q.
 Proof.
@@ -556,6 +566,7 @@ Proof.
     pattern p at 3; rewrite (Z_div_mod_eq_full p q); ring.
 Qed.
 
+#[deprecated(use=Z.coprime_mod_l_iff, since="9.1")]
 Theorem rel_prime_mod_rev: forall p q, 0 < q ->
  rel_prime (p mod q) q -> rel_prime p q.
 Proof.
@@ -564,6 +575,7 @@ Proof.
   apply Zis_gcd_sym; apply Zis_gcd_for_euclid2; auto.
 Qed.
 
+#[deprecated(note="unfold Z.coprime", since="9.1")]
 Theorem Zrel_prime_neq_mod_0: forall a b, 1 < b -> rel_prime a b -> a mod b <> 0.
 Proof.
   intros a b H H1 H2.
@@ -575,6 +587,7 @@ Qed.
 
 (** * Primality *)
 
+(** Note: prefer Z.prime *)
 Inductive prime (p:Z) : Prop :=
   prime_intro :
     1 < p -> (forall n:Z, 1 <= n < p -> rel_prime n p) -> prime p.
@@ -687,11 +700,13 @@ Proof.
   right; apply Gauss with a; auto with zarith.
 Qed.
 
+#[deprecated(use=Z.not_prime_0, since="9.1")]
 Lemma not_prime_0: ~ prime 0.
 Proof.
   intros H1; case (prime_divisors _ H1 2); auto with zarith; intuition; discriminate.
 Qed.
 
+#[deprecated(use=Z.not_prime_1, since="9.1")]
 Lemma not_prime_1: ~ prime 1.
 Proof.
   intros H1; absurd (1 < 1).
@@ -709,6 +724,7 @@ Proof.
     + subst n. constructor; auto with zarith.
 Qed.
 
+#[deprecated(use=Z.prime_3, since="9.1")]
 Theorem prime_3: prime 3.
 Proof.
   apply prime_intro; auto with zarith.
@@ -730,15 +746,17 @@ Proof.
   now intros (Hp,_); apply (Zlt_le_succ 1).
 Qed.
 
-Definition prime' p := 1<p /\ (forall n, 1<n<p -> ~ (n|p)).
+#[deprecated(use=Z.prime, since="9.1")]
+Notation prime' := Z.prime (only parsing).
 
+#[deprecated(note="Use lia", since="9.1")]
 Lemma Z_0_1_more x : 0<=x -> x=0 \/ x=1 \/ 1<x.
 Proof.
  intros H. Z.le_elim H; auto.
  apply Z.le_succ_l in H. change (1 <= x) in H. Z.le_elim H; auto.
 Qed.
 
-Theorem prime_alt p : prime' p <-> prime p.
+Theorem prime_alt p : Z.prime p <-> prime p.
 Proof.
   split; intros (Hp,H).
   - (* prime -> prime' *)
@@ -798,20 +816,24 @@ Proof.
       now rewrite Z.opp_involutive; apply Z.lt_le_incl.
 Qed.
 
+#[deprecated(use=Z.gcd_nonneg , since="9.1")]
 Notation Zgcd_is_pos := Z.gcd_nonneg (only parsing).
 
+#[deprecated(since="9.1")]
 Theorem Zgcd_spec : forall x y : Z, {z : Z | Zis_gcd x y z /\ 0 <= z}.
 Proof.
   intros x y; exists (Z.gcd x y).
   split; [apply Zgcd_is_gcd  | apply Z.gcd_nonneg].
 Qed.
 
+#[deprecated(use=Z.gcd_greatest, since="9.1")]
 Theorem Zdivide_Zgcd: forall p q r : Z,
  (p | q) -> (p | r) -> (p | Z.gcd q r).
 Proof.
  intros. now apply Z.gcd_greatest.
 Qed.
 
+#[deprecated(use=Z.gcd, since="9.1")]
 Theorem Zis_gcd_gcd: forall a b c : Z,
  0 <= c ->  Zis_gcd a b c -> Z.gcd a b = c.
 Proof.
@@ -826,9 +848,12 @@ Proof.
     + subst. now case (Z.gcd a b).
 Qed.
 
+#[deprecated(use=Z.gcd_eq_0_l , since="9.1")]
 Notation Zgcd_inv_0_l := Z.gcd_eq_0_l (only parsing).
+#[deprecated(use=Z.gcd_eq_0_r , since="9.1")]
 Notation Zgcd_inv_0_r := Z.gcd_eq_0_r (only parsing).
 
+#[deprecated(use=Z.gcd_div_swap, since="9.1")]
 Theorem Zgcd_div_swap0 : forall a b : Z,
  0 < Z.gcd a b ->
  0 < b ->
@@ -842,6 +867,7 @@ Proof.
   rewrite <- Zdivide_Zdiv_eq; auto.
 Qed.
 
+#[deprecated(use=Z.gcd_div_swap, since="9.1")]
 Theorem Zgcd_div_swap : forall a b c : Z,
  0 < Z.gcd a b ->
  0 < b ->
@@ -857,18 +883,23 @@ Proof.
   rewrite <- Zdivide_Zdiv_eq; auto.
 Qed.
 
+#[deprecated(use=Z.gcd_assoc, since="9.1")]
 Lemma Zgcd_ass a b c : Z.gcd (Z.gcd a b) c = Z.gcd a (Z.gcd b c).
 Proof.
  symmetry. apply Z.gcd_assoc.
 Qed.
 
+#[deprecated(use=Z.gcd_abs_l, since="9.1")]
 Notation Zgcd_Zabs := Z.gcd_abs_l (only parsing).
+#[deprecated(use=Z.gcd_0_r, since="9.1")]
 Notation Zgcd_0 := Z.gcd_0_r (only parsing).
+#[deprecated(use=Z.gcd_1_r, since="9.1")]
 Notation Zgcd_1 := Z.gcd_1_r (only parsing).
 
 #[global]
 Hint Resolve Z.gcd_0_r Z.gcd_1_r : zarith.
 
+#[deprecated(note="Use Z.gcd_greatest, Z.gcd_divide_l, or Z.gcd_divide_r", since="9.1")]
 Theorem Zgcd_1_rel_prime : forall a b,
  Z.gcd a b = 1 <-> rel_prime a b.
 Proof.
@@ -881,6 +912,7 @@ Proof.
       * generalize (Z.gcd_nonneg a b); auto with zarith.
 Qed.
 
+#[deprecated(use=Z.BoolSpec_coprime, since="9.1")]
 Definition rel_prime_dec: forall a b,
  { rel_prime a b }+{ ~ rel_prime a b }.
 Proof.
@@ -889,6 +921,7 @@ Proof.
   - right; contradict H1; apply <- Zgcd_1_rel_prime; auto.
 Defined.
 
+#[deprecated(since="9.1")]
 Definition prime_dec_aux:
  forall p m,
   { forall n, 1 < n < m -> rel_prime n p } +

--- a/theories/ZArith/Zpow_facts.v
+++ b/theories/ZArith/Zpow_facts.v
@@ -8,8 +8,9 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-From Stdlib Require Import BinInt Znat ZArithRing Lia Wf_Z Zcomplements Zdiv Znumtheory.
+From Stdlib Require Import BinInt Znat ZArithRing Lia Wf_Z Zcomplements Zdiv Zdivisibility.
 From Stdlib Require Export Zpower.
+From Stdlib Require Znumtheory.
 Local Open Scope Z_scope.
 
 (** Properties of the power function over [Z] *)
@@ -169,22 +170,23 @@ Proof.
   rewrite Z.mul_comm, <- Z.pow_succ_r by lia; f_equal; lia.
 Qed.
 
+#[deprecated(use=Z.coprime_pow_r, since="9.1")]
 Theorem rel_prime_Zpower_r i p q :
- 0 <= i -> rel_prime p q -> rel_prime p (q^i).
+ 0 <= i -> Znumtheory.rel_prime p q -> Znumtheory.rel_prime p (q^i).
 Proof.
-  intros Hi Hpq; pattern i; apply natlike_ind; auto with zarith.
-  - simpl. apply rel_prime_sym, rel_prime_1.
-  - clear i Hi. intros i Hi Rec; rewrite Z.pow_succ_r; auto.
-    apply rel_prime_mult; auto.
+  setoid_rewrite Znumtheory.rel_prime_iff_coprime.
+  apply Z.coprime_pow_r.
 Qed.
 
+#[deprecated(use=Z.coprime_pow_l, since="9.1")]
 Theorem rel_prime_Zpower i j p q :
- 0 <= i ->  0 <= j -> rel_prime p q -> rel_prime (p^i) (q^j).
+ 0 <= i ->  0 <= j -> Znumtheory.rel_prime p q -> Znumtheory.rel_prime (p^i) (q^j).
 Proof.
- intros Hi Hj H. apply rel_prime_Zpower_r; trivial.
- apply rel_prime_sym. apply rel_prime_Zpower_r; trivial.
- now apply rel_prime_sym.
+  setoid_rewrite Znumtheory.rel_prime_iff_coprime.
+  intros. apply Z.coprime_pow_l; try apply Z.coprime_pow_r; trivial.
 Qed.
+
+Import Znumtheory.
 
 Theorem prime_power_prime p q n :
  0 <= n -> prime p -> prime q -> (p | q^n) -> p = q.
@@ -237,5 +239,7 @@ Qed.
 
 (** * Z.square: a direct definition of [z^2] *)
 
+#[deprecated(use=Pos.square_spec, since="9.1")]
 Notation Psquare_correct := Pos.square_spec (only parsing).
+#[deprecated(use=Z.square_spec, since="9.1")]
 Notation Zsquare_correct := Z.square_spec (only parsing).

--- a/theories/ZArith/Zquot.v
+++ b/theories/ZArith/Zquot.v
@@ -162,13 +162,7 @@ Definition Remainder_alt a b r :=
 Lemma Remainder_equiv : forall a b r,
  Remainder a b r <-> Remainder_alt a b r.
 Proof.
-  unfold Remainder, Remainder_alt; intuition auto with zarith.
-  - lia.
-  - lia.
-  - rewrite <-(Z.mul_opp_opp). apply Z.mul_nonneg_nonneg; lia.
-  - assert (0 <= Z.sgn r * Z.sgn a).
-    { rewrite <-Z.sgn_mul, Z.sgn_nonneg; auto. }
-    destruct r; simpl Z.sgn in *; lia.
+  unfold Remainder, Remainder_alt; lia.
 Qed.
 
 Theorem Zquot_mod_unique_full a b q r :
@@ -367,9 +361,9 @@ Lemma Zrem_divides : forall a b,
  Z.rem a b = 0 <-> exists c, a = b*c.
 Proof.
  intros. zero_or_not b.
- - firstorder.
+ - firstorder idtac.
  - rewrite Z.rem_divide; trivial.
-   split; intros (c,Hc); exists c; subst; auto with zarith.
+   split; intros (c,Hc); exists c; lia.
 Qed.
 
 (** Particular case : dividing by 2 is related with parity *)
@@ -377,11 +371,7 @@ Qed.
 Lemma Zquot2_odd_remainder : forall a,
  Remainder a 2 (if Z.odd a then Z.sgn a else 0).
 Proof.
- intros [ |p|p].
- - simpl.
-   left. simpl. auto with zarith.
- - left. destruct p; simpl; lia.
- - right. destruct p; simpl; split; now auto with zarith.
+  intros [ |[]|[]]; cbn; (left + right); lia.
 Qed.
 
 Lemma Zrem_odd : forall a, Z.rem a 2 = if Z.odd a then Z.sgn a else 0.

--- a/theories/micromega/ZMicromega.v
+++ b/theories/micromega/ZMicromega.v
@@ -400,9 +400,6 @@ Qed.
 
 
 
-From Stdlib.micromega Require Import Tauto.
-From Stdlib Require Import BinNums.
-
 Definition cnf_of_list {T: Type} (tg : T) (l : list (NFormula Z)) :=
   List.fold_right (fun x acc =>
                      if Zunsat x then acc else ((x,tg)::nil)::acc)
@@ -520,13 +517,13 @@ Definition ceiling (a b:Z) : Z :=
     end.
 
 
-From Stdlib Require Import Znumtheory.
-
 Lemma Zdivide_ceiling : forall a b, (b | a) -> ceiling a b = Z.div a b.
 Proof.
   unfold ceiling.
   intros a b H.
-  apply Zdivide_mod in H.
+  assert (mod0_divide : forall a b, (b | a) -> a mod b = 0).
+  { intros ? ? (?,->); apply Z_mod_mult. }
+  apply mod0_divide in H.
   case_eq (Z.div_eucl a b).
   intros z z0 H0.
   change z with (fst (z,z0)).
@@ -586,7 +583,6 @@ Register ExProof     as micromega.ZArithProof.ExProof.
    - b is the constant
    - a is the gcd of the other coefficient.
 *)
-From Stdlib Require Import Znumtheory.
 
 Definition isZ0 (x:Z) :=
   match x with
@@ -641,7 +637,8 @@ Proof.
   - (* Pc *)
     simpl.
     intros.
-    apply Zdivide_Zdiv_eq ; auto.
+    rewrite <-Z.divide_div_mul_exact, Z.mul_comm, Z.div_mul;
+      try symmetry; auto using Z.lt_neq.
   - (* Pinj *)
     simpl.
     intros.
@@ -686,12 +683,8 @@ Qed.
 
 Lemma Zgcd_minus : forall a b c, (a | c - b ) -> (Z.gcd a b | c).
 Proof.
-  intros a b c (q,Hq).
-  destruct (Zgcd_is_gcd a b) as [(a',Ha) (b',Hb) _].
-  set (g:=Z.gcd a b) in *; clearbody g.
-  exists (q * a' + b').
-  symmetry in Hq. rewrite <- Z.add_move_r in Hq.
-  rewrite <- Hq, Hb, Ha. ring.
+  intros a b c [q Hq%Z.sub_move_r]; subst.
+  auto using Z.divide_add_r, Z.divide_mul_r, Z.gcd_divide_l, Z.gcd_divide_r.
 Qed.
 
 Lemma Zdivide_pol_sub : forall p a b,
@@ -712,7 +705,7 @@ Proof.
     inv H0.
     constructor.
     + apply Zdivide_pol_Zdivide with (1:= (ltac:(assumption) : Zdivide_pol a p)).
-      destruct (Zgcd_is_gcd a b) ; assumption.
+      apply Z.gcd_divide_l.
     + apply IHp2 ; assumption.
 Qed.
 
@@ -769,12 +762,12 @@ Proof.
         -- unfold ZgcdM in HH1. unfold ZgcdM.
            destruct (Z.max_spec  (Z.gcd z1 z2)  1) as [HH2 | HH2]; cycle 1.
            ++ destruct HH2 as [H1 H2]. rewrite H2 in *.
-              destruct (Zgcd_is_gcd (Z.gcd z1 z2) z); auto.
+              apply Z.gcd_divide_l.
            ++ destruct HH2 as [H1 H2]. rewrite H2.
-              destruct (Zgcd_is_gcd 1  z); auto.
+              apply Z.gcd_divide_l.
       * apply (Zdivide_pol_Zdivide _ z).
         -- apply (IHp2 _ _ H); auto.
-        -- destruct (Zgcd_is_gcd (ZgcdM z1 z2) z); auto.
+        -- apply Z.gcd_divide_r.
     + constructor.
       * apply Zdivide_pol_one.
       * apply Zdivide_pol_one.
@@ -1173,7 +1166,7 @@ Proof.
     rewrite <- H1.
     assumption.
     (* g <= 0 *)
-  - intros H0 H1 H2. inv H2. auto with zarith.
+  - inversion 3; subst; auto using Z.add_nonneg_nonneg, Z.le_refl.
 Qed.
 
 Lemma cutting_plane_sound : forall env f p,
@@ -1280,13 +1273,9 @@ Proof.
       rewrite Zgcd_pol_correct_lt with (1:= H0) in H2. 2: auto using Z.gt_lt.
       set (x:=eval_pol env (Zdiv_pol (PsubC Z.sub p c) g)) in *; clearbody x.
       contradict H5.
-      apply Zis_gcd_gcd.
+      apply Z.add_move_0_l in H2; subst c.
+      rewrite Z.gcd_opp_r, Z.gcd_mul_diag_l; trivial.
       * apply Z.lt_le_incl; assumption.
-      * constructor; auto with zarith.
-        exists (-x).
-        rewrite Z.mul_opp_l, Z.mul_comm.
-        now apply Z.add_move_0_l.
-        (**)
     + destruct (makeCuttingPlane p);  discriminate.
   - discriminate.
   - destruct (makeCuttingPlane (PsubC Z.sub p 1)) ; discriminate.

--- a/theories/nsatz/NsatzTactic.v
+++ b/theories/nsatz/NsatzTactic.v
@@ -22,7 +22,6 @@ From Stdlib Require Import List.
 From Stdlib Require Import Setoid.
 From Stdlib Require Import BinPos.
 From Stdlib Require Import BinList.
-From Stdlib Require Import Znumtheory.
 From Stdlib Require Export Morphisms Setoid Bool.
 From Stdlib Require Export Algebra_syntax.
 From Stdlib Require Export Ncring.

--- a/theories/setoid_ring/Cring.v
+++ b/theories/setoid_ring/Cring.v
@@ -12,7 +12,6 @@ From Stdlib Require Export List.
 From Stdlib Require Import Setoid.
 From Stdlib Require Import BinPos.
 From Stdlib Require Import BinList.
-From Stdlib Require Import Znumtheory.
 From Stdlib Require Export Morphisms Setoid Bool.
 From Stdlib Require Import BinInt.
 From Stdlib Require Export Algebra_syntax.
@@ -188,7 +187,6 @@ Ltac cring_simplify_aux lterm fv lexpr hyp :=
             rewrite eq1;
             pattern (@Ring_polynom.Pphi_dev
             _ 0 1 _+_ _*_ _-_ -_
-
             Z 0%Z 1%Z Z.eqb
             Ncring_initial.gen_phiZ
             get_signZ fv t');

--- a/theories/setoid_ring/Integral_domain.v
+++ b/theories/setoid_ring/Integral_domain.v
@@ -8,6 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+From Stdlib Require Import BinNatDef.
 From Stdlib Require Export Cring.
 Import BinNat.
 

--- a/theories/setoid_ring/Ncring_initial.v
+++ b/theories/setoid_ring/Ncring_initial.v
@@ -9,18 +9,8 @@
 (************************************************************************)
 
 From Stdlib Require Import BinInt.
-From Stdlib Require Import Zpow_def.
-From Stdlib Require Import BinInt.
-From Stdlib Require Import BinNat.
-From Stdlib Require Import Setoid.
-From Stdlib Require Import BinList.
-From Stdlib Require Import BinPos.
-From Stdlib Require Import BinNat.
-From Stdlib Require Import BinInt.
-From Stdlib Require Import Setoid.
 From Stdlib Require Export Ncring.
 From Stdlib Require Export Ncring_polynom.
-From Stdlib Require Zbool.
 
 Set Implicit Arguments.
 

--- a/theories/setoid_ring/Ncring_tac.v
+++ b/theories/setoid_ring/Ncring_tac.v
@@ -12,7 +12,7 @@ From Stdlib Require Import List.
 From Stdlib Require Import Setoid.
 From Stdlib Require Import BinPos.
 From Stdlib Require Import BinList.
-From Stdlib Require Import Znumtheory.
+From Stdlib Require Import BinInt.
 From Stdlib Require Export Morphisms Setoid Bool.
 From Stdlib Require Import Algebra_syntax.
 From Stdlib Require Export Ncring.


### PR DESCRIPTION
Repeat of approved PR https://github.com/coq/coq/pull/19789

Overlays (optional since addition of a compat Require):

- [x] https://github.com/mit-plv/bedrock2/pull/455
- [x] https://github.com/mit-plv/fiat-crypto/pull/2081
- [x] https://github.com/AbsInt/CompCert/pull/548
- [ ] https://github.com/math-comp/mczify/pull/60
- [ ] https://gitlab.mpi-sws.org/iris/stdpp/-/merge_requests/605