### PR TITLE
correct typos in deprecated warnings in Zbool.v

### DIFF
--- a/theories/ZArith/Zbool.v
+++ b/theories/ZArith/Zbool.v
@@ -152,13 +152,13 @@ Definition Zeven_odd_bool (x:Z) := bool_of_sumbool (Zeven_odd_dec x).
 (**********************************************************************)
 (** * Boolean comparisons of binary integers *)
 
-#[deprecated(use=Z.eqb, since="9.0")]
+#[deprecated(use=Z.leb, since="9.0")]
 Notation Zle_bool := Z.leb (only parsing).
-#[deprecated(use=Z.eqb, since="9.0")]
+#[deprecated(use=Z.geb, since="9.0")]
 Notation Zge_bool := Z.geb (only parsing).
-#[deprecated(use=Z.eqb, since="9.0")]
+#[deprecated(use=Z.ltb, since="9.0")]
 Notation Zlt_bool := Z.ltb (only parsing).
-#[deprecated(use=Z.eqb, since="9.0")]
+#[deprecated(use=Z.gtb, since="9.0")]
 Notation Zgt_bool := Z.gtb (only parsing).
 
 (** We now provide a direct [Z.eqb] that doesn't refer to [Z.compare].


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/stdlib/blob/master/CONTRIBUTING.md

Changelog: https://github.com/coq/stdlib/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/stdlib/blob/master/doc/README.md
Sphinx: https://github.com/coq/stdlib/blob/master/doc/sphinx/README.rst

Overlays: https://github.com/coq/stdlib/blob/master/dev/doc/README-CI.md
