### PR TITLE
removed alias Zmod:=Z.modulo (deprecated since 8.17)

### DIFF
--- a/doc/changelog/04-removed/149-remove-alias-Zmod.rst
+++ b/doc/changelog/04-removed/149-remove-alias-Zmod.rst
@@ -1,0 +1,6 @@
+- in `Zdiv.v`
+
+  + alias `Zmod` for `Z.modulo`, deprecated since 8.17
+    (`#149 <https://github.com/coq/stdlib/pull/149>`_,
+    by Andres Erbsen).
+

--- a/theories/ZArith/Zdiv.v
+++ b/theories/ZArith/Zdiv.v
@@ -22,8 +22,6 @@ Local Open Scope Z_scope.
 
 #[deprecated(since="8.17",note="Use Coq.ZArith.BinIntDef.Z.pos_div_eucl instead")]
 Notation Zdiv_eucl_POS := Z.pos_div_eucl (only parsing).
-#[deprecated(since="8.17",note="Use Coq.ZArith.BinIntDef.Z.modulo instead")]
-Notation Zmod := Z.modulo (only parsing).
 
 #[deprecated(since="8.17",note="Use BinInt.Z.pos_div_eucl_bound instead")]
 Notation Zmod_POS_bound := Z.pos_div_eucl_bound (only parsing).


### PR DESCRIPTION
- [x] Added **changelog**.
- [x] Opened **overlay** pull requests.
  - [x] https://gitlab.inria.fr/flocq/flocq/-/commit/fab16db5d9ae0caeb7df822e1cdff1c93b9555e8
  - [x] https://github.com/rocq-community/math-classes/pull/134