### PR TITLE
Zmod nsatz

### DIFF
--- a/doc/changelog/02-added/156-zmod-nsatz.rst
+++ b/doc/changelog/02-added/156-zmod-nsatz.rst
@@ -1,0 +1,14 @@
+- in `ZmodNsatz` and `Zmod`
+
+  + Added support for the `nsatz` tactic on `Zmod`
+    (`#156 <https://github.com/coq/stdlib/pull/156>`_,
+    by Andres Erbsen).
+
+- in `Ncring_tac`
+
+  + Added extension-point typeclass `extra_reify` that is only resolved on
+    non-variables for which built-in syntax-directed reification did not find a
+    match
+    (`#156 <https://github.com/coq/stdlib/pull/156>`_,
+    by Andres Erbsen).
+

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -322,6 +322,7 @@ through the <tt>From Stdlib Require Import</tt> command.</p>
     (theories/Zmod/ZmodBase.v)
     (theories/Zmod/ZstarBase.v)
     (theories/Zmod/ZmodInv.v)
+    (theories/Zmod/ZmodNsatz.v)
   </dd>
 
   <dt> <a name="unicode"></a><b>Unicode</b>:

--- a/test-suite/success/Nsatz.v
+++ b/test-suite/success/Nsatz.v
@@ -1,6 +1,5 @@
 (* This file takes 9 seconds to process on a 2023 gaming computer *)
-From Stdlib Require Import List BinNat BinInt QArith_base Rbase RNsatz ZNsatz QNsatz.
-Import List.ListNotations.
+From Stdlib Require Import List BinNat ZArith Zdivisibility Zmod QArith Rbase RNsatz.
 
 (* Example with a generic domain *)
 
@@ -15,6 +14,18 @@ Lemma example3_Z : forall (x y z : Z), (
   x*y*z=0 -> x*x*x=0)%Z.
 Proof. nsatz. Qed.
 
+Lemma example3_Zmod3 : forall (x y z : Zmod 3), (
+  x+y+z=0 ->
+  x*y+x*z+y*z=0->
+  x*y*z=0 -> x^3=0)%Zmod.
+Proof. nsatz. Qed.
+
+Lemma example3_Zmodp : forall p (x y z : Zmod p), Z.prime p -> (
+  x+y+z=0 ->
+  x*y+x*z+y*z=0->
+  x*y*z=0 -> x^3=0)%Zmod.
+Proof. nsatz. Qed.
+
 Lemma example3_Q : forall (x y z : Q), (
   x+y+z==0 ->
   x*y+x*z+y*z==0->
@@ -26,6 +37,23 @@ Lemma example3_R : forall (x y z : R), (
   x*y+x*z+y*z=0->
   x*y*z=0 -> x*x*x=0)%R.
 Proof. nsatz. Qed.
+
+Lemma example_contradiction_Zmod3 : forall (x : Zmod 3), (
+  x = Zmod.of_Z _ 2 ->
+  x = Zmod.of_Z _ 1 ->
+  0 = 1 :> Zmod 3)%Zmod.
+Proof. nsatz. Qed.
+
+Lemma example_contradiction_Zmodp : forall p (x : Zmod p), Z.prime p -> (
+  x = Zmod.of_Z _ 2 ->
+  x = Zmod.of_Z _ 1 ->
+  0 = 1 :> Zmod p)%Zmod.
+Proof.
+  intros.
+  assert_succeeds (nsatz; []). (* (1+1)%Zmod is not converitble with (Zmod.of_Z p 2) *)
+  pose proof @Zmod.of_Z_add p 1 1.
+  nsatz.
+Qed.
 
 Import Integral_domain Algebra_syntax.
 
@@ -64,7 +92,7 @@ Proof. nsatz. Qed.
 End test.
 
 Section Geometry.
-Import Algebra_syntax.
+Import Algebra_syntax List.ListNotations.
 Local Open Scope R_scope.
 Local Coercion IZR : Z >-> R.
 

--- a/theories/All/All.v
+++ b/theories/All/All.v
@@ -578,3 +578,4 @@ From Stdlib Require Export Zmod.Zstar.
 From Stdlib Require Export Zmod.ZstarDef.
 From Stdlib Require Export Zmod.ZstarBase.
 From Stdlib Require Export Zmod.Bits.
+From Stdlib Require Export Zmod.ZmodNsatz.

--- a/theories/Make.zmod
+++ b/theories/Make.zmod
@@ -6,5 +6,6 @@ Zmod/ZmodInv.v
 Zmod/Zstar.v
 Zmod/ZstarBase.v
 Zmod/ZstarDef.v
+Zmod/ZmodNsatz.v
 
 -Q Zmod Stdlib.Zmod

--- a/theories/Reals/RNsatz.v
+++ b/theories/Reals/RNsatz.v
@@ -15,15 +15,13 @@ From Stdlib Require Import Raxioms RIneq DiscrR.
 
 Ltac nsatz_internal_discrR ::= discrR.
 
-Ltac Ncring_tac.extra_reify term ::=
-  lazymatch term with
-  | IZR ?z =>
-      lazymatch isZcst z with
-      | true => open_constr:(PEc z)
-      | false => open_constr:(tt)
-      end
-  | _ => open_constr:(tt)
+Local Ltac extra_reify :=
+  lazymatch goal with |- Ncring_tac.extra_reify _ (IZR ?z) =>
+    lazymatch isZcst z with
+    | true => exact (PEc z)
+    end
   end.
+#[export] Hint Extern 1 (Ncring_tac.extra_reify _ _) => extra_reify : typeclass_instances.
 
 #[export] Instance Rops: @Ring_ops R 0%R 1%R Rplus Rmult Rminus Ropp (@eq R) := {}.
 

--- a/theories/ZArith/Zdivisibility.v
+++ b/theories/ZArith/Zdivisibility.v
@@ -92,6 +92,7 @@ Proof. symmetry. apply coprime_pow_r; try symmetry; trivial. Qed.
 
 
 Definition prime p := 1 < p /\ forall n, 1 < n < p -> ~ (n|p).
+Existing Class prime.
 
 Lemma not_prime_0 : not (prime 0).
 Proof. intros []. lia. Qed.
@@ -227,3 +228,6 @@ Proof. cbv [extgcd proj1_sig]. case extgcd_rec as (([],?),?). intuition congruen
 End extended_euclid_algorithm.
 
 End Z.
+
+#[export] Hint Extern 0 (Z.prime 2) => exact Z.prime_2 : typeclass_instances.
+#[export] Hint Extern 0 (Z.prime 3) => exact Z.prime_3 : typeclass_instances.

--- a/theories/Zmod/Zmod.v
+++ b/theories/Zmod/Zmod.v
@@ -3,3 +3,4 @@ From Stdlib Require Export ZArith ZModOffset Lia.
 From Stdlib Require Export Zmod.ZmodDef.
 From Stdlib Require Export Zmod.ZmodBase.
 From Stdlib Require Export Zmod.ZmodInv.
+From Stdlib Require Export Zmod.ZmodNsatz.

--- a/theories/Zmod/ZmodDef.v
+++ b/theories/Zmod/ZmodDef.v
@@ -160,6 +160,8 @@ End bits.
 Declare Scope Zmod_scope.
 Delimit Scope Zmod_scope with Zmod.
 Bind Scope Zmod_scope with Zmod.
+Notation "0" := Zmod.zero : Zmod_scope.
+Notation "1" := Zmod.one : Zmod_scope.
 Infix "+" := Zmod.add : Zmod_scope.
 Infix "-" := Zmod.sub : Zmod_scope.
 Notation "- x" := (Zmod.opp x) : Zmod_scope.

--- a/theories/Zmod/ZmodNsatz.v
+++ b/theories/Zmod/ZmodNsatz.v
@@ -1,0 +1,59 @@
+Require Export (ltac.notations) NsatzTactic.
+
+Require Import Zdivisibility Lia NsatzTactic.
+Require Import ZmodDef ZmodBase ZmodInv.
+
+#[export]
+Instance Ring_ops_Zmod m : @Ring_ops (Zmod m) Zmod.zero Zmod.one Zmod.add Zmod.mul Zmod.sub Zmod.opp Logic.eq := {}.
+
+#[export]
+Instance Ring_Zmod m : Ring (Ro:=Ring_ops_Zmod m).
+Proof.
+  split.
+  { apply eq_equivalence. }
+  1,2,3,4 : Morphisms.solve_proper.
+  { apply Zmod.add_0_l. }
+  { apply Zmod.add_comm. }
+  { apply Zmod.add_assoc. }
+  { apply Zmod.mul_1_l. }
+  { apply Zmod.mul_1_r. }
+  { apply Zmod.mul_assoc. }
+  { apply Zmod.mul_add_l. }
+  { intros ? ? ?. apply Zmod.mul_add_r. }
+  { symmetry; apply Zmod.add_opp_r. }
+  { apply Zmod.add_opp_same_r. }
+Qed.
+
+#[export]
+Instance Cring_ZMod m : Cring (Rr:=Ring_Zmod m).
+Proof.
+  cbv [Cring].
+  apply Zmod.mul_comm.
+Qed.
+
+#[export]
+Instance Integral_domain_Zmod m : Z.prime m -> Integral_domain (Rr:=Ring_Zmod m).
+Proof.
+  intros H; split.
+  { apply Zmod.mul_0_iff_prime, H. }
+  { apply Zmod.one_neq_zero. pose proof Z.prime_ge_2 _ H. lia. }
+Qed.
+
+Local Ltac extra_reify_of_Z :=
+  lazymatch goal with |- Ncring_tac.extra_reify _ (@Zmod.of_Z ?m ?z) =>
+  constr_eq true ltac:(isZcst m);
+  constr_eq true ltac:(isZcst z);
+  exact (PEc z)
+  end.
+
+Local Ltac extra_reify_pow_pos :=
+  lazymatch goal with |- @Ncring_tac.extra_reify ?R ?ring0 ?ring1 ?add ?mul ?sub ?opp ?lvar (Zmod.pow ?t (Z.pos ?p)) =>
+  constr_eq true ltac:(isPcst p);
+  let et := Ncring_tac.reify_term R ring0 ring1 add mul sub opp lvar t in
+  exact (PEpow et (BinNat.N.pos p))
+  end.
+
+#[export] Hint Extern 1 (Ncring_tac.extra_reify _ (Zmod.of_Z ?m ?z)) => extra_reify_of_Z : typeclass_instances.
+#[export] Hint Extern 1 (Ncring_tac.extra_reify _ (Zmod.pow _ (Z.pos _))) => extra_reify_pow_pos : typeclass_instances.
+#[export] Hint Extern 1 (Ncring_tac.extra_reify _ (Zmod.pow _ Z0)) => exact (PEc 0%Z) : typeclass_instances.
+(* [Zmod.pow _ (Z.neg) = Zmod.inv (Zmod.pow _ _)] can't be reified directly *)


### PR DESCRIPTION
- [x] Added **changelog**.
- [x] Added / updated **documentation**.

In https://github.com/rocq-prover/rocq/pull/18325 , Ltac-driven reification was sufficient because the extension point was used only once. Here we have two users (R and Zmod), so I introduced a hint-extern typeclass just for the extension case.