### PR TITLE
Add new tactic "ensatz" for proving polynomial equalities with existential quantifier

### DIFF
--- a/doc/changelog/02-added/160-feature-ensatz.rst
+++ b/doc/changelog/02-added/160-feature-ensatz.rst
@@ -1,0 +1,17 @@
+- in `ENsatzTactic`
+
+  + Add new tactic `ensatz` for proving polynomial equalities
+    with existential quantifier
+    (`#160 <https://github.com/coq/stdlib/pull/160>`_,
+    by Lionel Blatter).
+
+- Add documentation for new tactic `ensatz`
+  (`#20762 <https://github.com/rocq-prover/rocq/pull/20762>`_,
+  by Lionel Blatter).
+
+- in `ENsatz`
+
+  + Add tests for tactic `ensatz`
+    (`#160 <https://github.com/coq/stdlib/pull/160>`_,
+    by Lionel Blatter).
+

--- a/doc/changelog/02-added/160-feature-ensatz.rst
+++ b/doc/changelog/02-added/160-feature-ensatz.rst
@@ -1,7 +1,7 @@
 - in `ENsatzTactic`
 
   + Add new tactic `ensatz` for proving polynomial equalities
-    with existential quantifier
+    with existential quantifiers or existential variables
     (`#160 <https://github.com/coq/stdlib/pull/160>`_,
     by Lionel Blatter).
 

--- a/test-suite/success/ENsatz.v
+++ b/test-suite/success/ENsatz.v
@@ -1,0 +1,426 @@
+From Stdlib Require Import Znumtheory.
+From Stdlib Require Import ZArith.
+From Stdlib Require Import ZNsatz.
+From Stdlib Require Import ENsatzTactic.
+From Stdlib Require Import Cring.
+From Stdlib Require Import Lia.
+
+Lemma modulo1 a b c: (a mod b = c -> exists k, a - c = k*b)%Z.
+Proof.
+  intros.
+  destruct (Z.eq_dec b 0) as [H1 | H1].
+    - subst.
+      exists 0%Z.
+      rewrite Zmod_0_r.
+      rewrite Z.sub_diag.
+      rewrite Z.mul_0_l.
+      trivial.
+    - specialize (Zmod_divides (a -c)%Z b H1).
+      rewrite Zminus_mod.
+      rewrite H.
+      rewrite Zminus_mod_idemp_r.
+      rewrite Z.sub_diag.
+      rewrite Zmod_0_l.
+      intros [H2 _].
+      destruct (H2 eq_refl).
+      exists x.
+      rewrite Z.mul_comm.
+      trivial.
+Qed.
+
+Lemma modulo2 a b c: ((exists k, a - c = k*b) -> a mod b = c mod b)%Z.
+Proof.
+  intros. destruct H.
+  rewrite Z.sub_move_r in H.
+  subst.
+  rewrite Z.add_comm.
+  rewrite Z_mod_plus_full.
+  reflexivity.
+Qed.
+
+Lemma div1 a b : ((a | b)  -> exists k, b = k*a)%Z.
+Proof.
+  intros.
+  destruct (Z.eq_dec a 0) as [H1 | H1].
+    - subst.
+      exists 0%Z.
+      apply Z.divide_0_l in H.
+      subst. reflexivity.
+    - apply Zdivide_mod in H.
+      apply (Zmod_divides _ _ H1 ) in H.
+      destruct H.
+      rewrite Z.mul_comm in H.
+      exists x. trivial.
+Qed.
+
+Lemma div2 a b : ((exists k, b = k*a) -> (a | b))%Z.
+Proof.
+ intros.
+ destruct (Z.eq_dec a 0) as [H1 | H1].
+    - subst.
+      destruct H.
+      rewrite Z.mul_0_r in H.
+      subst.
+      apply Z.divide_0_r.
+    - assert (H': exists k:Z, b = a * k).
+      destruct H. exists x. rewrite Z.mul_comm. trivial.
+      apply (Zmod_divides _ _ H1) in H'.
+      apply (Zmod_divide _ _ H1 H').
+Qed.
+
+Ltac div_to_equality H x y := try (apply (div1 x y) in H).
+
+Ltac divs_to_equalities :=
+  lazymatch goal with
+  |  H: (?x | ?y)%Z |- _ => div_to_equality H x y
+   end.
+
+Ltac mod_to_equality H x y z:= try (apply (modulo1 x y z) in H).
+
+Ltac mods_to_equalities :=
+  lazymatch goal with
+  |  H: (?z = ?x mod ?y)%Z |- _ => apply symmetry in H; mods_to_equalities
+  |  H: (?x mod ?y = ?z)%Z |- _ => mod_to_equality H x y z
+  end.
+
+Ltac exists_to_equalities :=
+  lazymatch goal with
+  | H: (exists e: ?A, ?b1) |- _ => destruct H
+  end.
+
+Ltac get_mods_aux a :=
+  match a with
+  | context [?a mod ?b] =>
+      first [get_mods_aux a | get_mods_aux b |
+      let j := fresh "j" in
+      let Hj := fresh "Hj" in
+      remember (a mod b) as j eqn: Hj]
+  end.
+
+Ltac get_mods :=
+  match goal with
+    |- context [?a mod ?b] =>
+      let t := constr:(a mod b) in
+      get_mods_aux t
+  end.
+
+Ltac preprocess :=
+  intros;
+  repeat mods_to_equalities;
+  repeat divs_to_equalities;
+  repeat exists_to_equalities;
+  match goal with
+  | |- (?x mod ?n)%Z = (?y mod ?n)%Z => apply modulo2
+  | |- (?x | ?y)%Z => apply div2
+  | |- ?g => idtac
+  end;
+  repeat (get_mods;  mods_to_equalities;  exists_to_equalities).
+
+(*
+     Examples of the Stdlib.
+*)
+
+Example mod_mod_divide: forall a b c : Z, (c | b) -> (a mod b) mod c = a mod c.
+Proof.
+  preprocess.
+  Time ensatz.
+Qed.
+
+Example mod_mod_divide2: forall a b c : Z, (c | b) -> ((a mod b) mod b) mod c = a mod c.
+  preprocess.
+  Time ensatz.
+Qed.
+
+Example Zmult_mod_idemp_l : forall a b n : Z, (a mod n * b) mod n = (a * b) mod n.
+Proof.
+  preprocess.
+  Time ensatz.
+Qed.
+
+Example Zplus_mod_idemp_l: forall a b n : Z, (a mod n + b) mod n = (a + b) mod n.
+Proof.
+  preprocess.
+  Time ensatz.
+Qed.
+
+Example Zplus_mod: forall a b n : Z, (a + b) mod n = (a mod n + b mod n) mod n.
+Proof.
+  preprocess.
+  Time ensatz.
+Qed.
+
+Example Zmult_mod: forall a b n : Z, (a * b) mod n = (a mod n * (b mod n)) mod n.
+Proof.
+  preprocess.
+  Time ensatz.
+Qed.
+
+Example mod_mod_opp_r: forall a b : Z, (a mod - b) mod b = a mod b.
+Proof.
+  preprocess.
+  Time ensatz.
+Qed.
+
+Example cong: forall a b m : Z, (a - b) mod m = 0%Z -> a mod m = b mod m.
+Proof.
+  preprocess.
+  Time ensatz.
+Qed.
+
+(* *)
+(*      Example of the paper "Automating elementary number-theoretic proofs *)
+(*      using Gröbner bases" by John Harrison. *)
+(* *)
+Example cancellation_congruence a n x y:
+  (a * x = (a * y) mod n -> (exists e1 e2, a * e1 + n * e2 = 1) -> y mod n = x mod n)%Z.
+Proof.
+  preprocess.
+  Time ensatz.
+Qed.
+
+(* *)
+(*      Examples of the paper "Connecting Gröbner bases programs with Coq to *)
+(*      do proofs in algebra, geometry and arithmetics" by Loïc Pottier. *)
+(* *)
+
+Definition modulo(a b p:Z):= exists k:Z, a - b = k*p.
+Definition ideal(x a b:Z):= exists u:Z, exists v:Z, x = u*a+v*b.
+Definition coprime(a b:Z):= exists u:Z, exists v:Z, 1 = u*a+v*b.
+Definition gcd(g a b:Z):= (g | a) /\ (g | b) /\ ideal g a b.
+
+Ltac integer_rule :=
+  repeat unfold modulo, coprime, ideal;
+  unfold Z.pow, Z.pow_pos; simpl;
+  preprocess; ensatz.
+
+Goal forall a b c:Z, (a | b*c) -> coprime a b -> (a | c).
+  integer_rule.
+Qed.
+
+Goal forall m n r:Z, (m | r ) -> (n | r) -> coprime m n -> (m*n | r).
+  integer_rule.
+Qed.
+
+Goal forall x y a n:Z, modulo (x*x) a n -> modulo (y*y) a n -> (n | (x+y)*(x-y)).
+  integer_rule.
+Qed.
+
+Goal forall x y:Z, (x+y | x^7+y^7).
+  integer_rule.
+Qed.
+
+Goal forall a b c:Z, (a | b*c) -> coprime a b -> (a | c).
+  integer_rule.
+Qed.
+
+Goal forall x y:Z, coprime (x*y) (x^2+y^2) <-> coprime x y.
+  split; integer_rule.
+Qed.
+
+Goal forall x y a n:Z, modulo (x+a) (y+a) n <-> modulo x y n.
+  split; integer_rule.
+Qed.
+
+Goal forall x n:Z, modulo x 0 n <-> (n | x).
+  split; integer_rule.
+Qed.
+
+Goal forall x y n:Z, modulo x y n -> (coprime n x <-> coprime n y).
+  intros * H; split; revert H; integer_rule.
+Qed.
+
+Goal forall a b x y:Z, gcd x a b -> (y | a) -> (y | b) -> (y | x).
+  intros * [H1 [H2 H3]]; revert H1 H2 H3.
+  integer_rule.
+Qed.
+
+Goal forall a x y n:Z, modulo (a*x) (a*y) n -> coprime a n -> modulo x y n.
+  integer_rule.
+Qed.
+
+Goal forall d a b:Z, (d | a) -> (d | b) -> (d | (a-b)).
+  integer_rule.
+Qed.
+
+Goal forall a b c:Z, (a | b) -> (c*a | c*b).
+  integer_rule.
+Qed.
+
+Goal forall x d a:Z, (x*d | a)  -> (d | a).
+  integer_rule.
+Qed.
+
+Goal forall a b c d:Z, (a | b) -> (c | d) -> (a*c | b*d).
+  integer_rule.
+Qed.
+
+Goal forall a b d:Z, coprime d a -> coprime d b -> coprime d (a*b).
+  integer_rule.
+Qed.
+
+Goal forall a b d:Z, coprime d (a*b) -> coprime d a.
+  integer_rule.
+Qed.
+
+Goal forall m n r:Z, (m | r)  -> (n | r) -> coprime m n -> (m*n | r).
+  integer_rule.
+Qed.
+
+Goal forall x x' y y' n:Z, modulo x x' n -> modulo y y' n -> modulo (x*y) (x'*y') n.
+  integer_rule.
+Qed.
+
+Goal forall x y m n:Z, modulo x y m -> (n | m) -> modulo x y n.
+  integer_rule.
+Qed.
+
+Goal forall a b x y:Z, coprime a b -> modulo x y a -> modulo x y b -> modulo x y (a*b).
+  integer_rule.
+Qed.
+
+Goal forall x y:Z, modulo (x^2) (y^2) (x+y).
+  integer_rule.
+Qed.
+
+Goal forall x y a n:Z, modulo (x^2) a n -> modulo (y^2) a n -> (n | (x+y)*(x-y)).
+  integer_rule.
+Qed.
+
+(* *)
+(*      Examples from HOL: *)
+(*      https://github.com/jrh13/hol-light/blob/master/Library/integer.ml *)
+(* *)
+
+Goal  forall d : Z, (d | d).
+  integer_rule.
+Qed.
+
+Goal forall x y z : Z, (x | y) -> (y | z) -> (x | z).
+  integer_rule.
+Qed.
+
+Goal forall d a b : Z, (d | a) -> (d | b) -> (d | a + b).
+  integer_rule.
+Qed.
+
+Goal forall d a b : Z, (d | a) -> (d | b) -> (d | a - b).
+  integer_rule.
+Qed.
+
+Goal forall d : Z, (d | 0).
+  integer_rule.
+Qed.
+
+Goal forall x : Z, (0 | x) <-> x = 0.
+  split; preprocess.
+  + subst. cring.
+  + ensatz.
+Qed.
+
+Goal forall d x : Z, ( -d | x) <->  (d | x).
+  split; integer_rule.
+Qed.
+
+Goal forall d x : Z, (d | --x) <-> (d | x).
+  split; integer_rule.
+Qed.
+
+Goal forall d x y : Z, (d | x) -> (d | x * y).
+  integer_rule.
+Qed.
+
+Goal forall d x y : Z, (d | y) -> (d | x * y).
+  integer_rule.
+Qed.
+
+Goal forall x : Z, ( 1 | x).
+  integer_rule.
+Qed.
+
+Goal forall d a b : Z, (d | a) -> (d | a + b) -> (d | b).
+  integer_rule.
+Qed.
+
+Goal forall d a b : Z, (d | b) -> (d | a + b) -> (d | a).
+  integer_rule.
+Qed.
+
+Goal forall a b c : Z, (a | b) -> (c * a | c * b).
+  integer_rule.
+Qed.
+
+Goal forall a b c : Z, (a | b) -> (a * c | b * c).
+  integer_rule.
+Qed.
+
+Goal forall d a x : Z, (x * d | a) -> (d | a).
+  integer_rule.
+Qed.
+
+Goal forall d a x : Z, (d * x | a) -> (d | a).
+  integer_rule.
+Qed.
+
+Goal forall a b c : Z, (c * a | c * b) -> c <> 0 -> (a | b).
+  intros * H; preprocess.
+  revert H.
+  rewrite <- Zmult_assoc_reverse, <- Z.mul_shuffle0, Z.mul_comm.
+  intros ?%(Z.mul_cancel_r b _ _ H0).
+  ensatz.
+Qed.
+
+Goal forall a b c : Z, c <> 0 -> ((c * a | c * b) <-> (a | b)).
+  intros * H0; split; intros H; preprocess.
+  + revert H.
+    rewrite <- Zmult_assoc_reverse, <- Z.mul_shuffle0, Z.mul_comm.
+    intros ?%(Z.mul_cancel_r b _ _ H0).
+    ensatz.
+  + ensatz.
+Qed.
+
+Goal forall a b c : Z, c <> 0 -> ((a * c | b * c) <-> (a |b)).
+  intros * H0;split; intros H; preprocess.
+  + revert H.
+    rewrite <- Zmult_assoc_reverse.
+    intros ?%(Z.mul_cancel_r b _ _ H0).
+    ensatz.
+  + ensatz.
+Qed.
+
+Goal forall a b c d : Z, (a | b)  -> (c | d) -> (a * c | b * d).
+  integer_rule.
+Qed.
+
+Goal forall x y n : Z,  (x | y) -> (x ^ n  | y ^ n).
+  preprocess.
+  destruct (Z.le_ge_cases 0 n) as [? | [? %(Z.pow_neg_r y)| -> ] %Zle_lt_or_eq].
+  - generalize dependent n.
+    apply natlike_rec2.
+    + ensatz.
+    + preprocess.
+      repeat rewrite Z.pow_succ_r by assumption.
+      ensatz.
+  - ensatz.
+  - ensatz.
+Qed.
+
+Goal forall n x y : Z, (0 <> n) /\ (x ^ n | y) -> (x | y).
+  intros n * [[ ? | ? %(Z.pow_neg_r x)] %not_Zeq ?]; preprocess; subst.
+  - assert (exists k, n = Z.succ k)
+      by (exists (Z.pred n); rewrite Z.succ_pred;reflexivity).
+    preprocess.
+    subst.
+    rewrite Z.pow_succ_r by (apply Zlt_succ_le;auto).
+    ensatz.
+  - ensatz.
+Qed.
+
+Require Import Reals RNsatz.
+
+Definition div(a b: R):= exists k: R, b = k*a.
+
+Goal forall x y z : R, div x y -> div y z -> div x z.
+  unfold div.
+  preprocess.
+  ensatz.
+Qed.

--- a/test-suite/success/ENsatz.v
+++ b/test-suite/success/ENsatz.v
@@ -1,7 +1,6 @@
 From Stdlib Require Import Znumtheory.
 From Stdlib Require Import ZArith.
 From Stdlib Require Import ZNsatz.
-From Stdlib Require Import ENsatzTactic.
 From Stdlib Require Import Cring.
 From Stdlib Require Import Lia.
 
@@ -46,7 +45,7 @@ Proof.
       exists 0%Z.
       apply Z.divide_0_l in H.
       subst. reflexivity.
-    - apply Zdivide_mod in H.
+    - apply Z.mod0_divide in H.
       apply (Zmod_divides _ _ H1 ) in H.
       destruct H.
       rewrite Z.mul_comm in H.
@@ -127,6 +126,7 @@ Proof.
 Qed.
 
 Example mod_mod_divide2: forall a b c : Z, (c | b) -> ((a mod b) mod b) mod c = a mod c.
+Proof.
   preprocess.
   Time ensatz.
 Qed.
@@ -164,6 +164,66 @@ Qed.
 Example cong: forall a b m : Z, (a - b) mod m = 0%Z -> a mod m = b mod m.
 Proof.
   preprocess.
+  Time ensatz.
+Qed.
+
+(* *)
+(*      Examples of the Stdlib with existantiel variables *)
+(* *)
+
+Goal forall a b c : Z, (c | b) -> (a mod b) mod c = a mod c.
+Proof.
+  preprocess.
+  eexists.
+  Time ensatz.
+Qed.
+
+Goal forall a b c : Z, (c | b) -> ((a mod b) mod b) mod c = a mod c.
+Proof.
+  preprocess.
+  eexists.
+  Time ensatz.
+Qed.
+
+Goal forall a b n : Z, (a mod n * b) mod n = (a * b) mod n.
+Proof.
+  preprocess.
+  eexists.
+  Time ensatz.
+Qed.
+
+Goal forall a b n : Z, (a mod n + b) mod n = (a + b) mod n.
+Proof.
+  preprocess.
+  eexists.
+  Time ensatz.
+Qed.
+
+Goal forall a b n : Z, (a + b) mod n = (a mod n + b mod n) mod n.
+Proof.
+  preprocess.
+  eexists.
+  Time ensatz.
+Qed.
+
+Goal forall a b n : Z, (a * b) mod n = (a mod n * (b mod n)) mod n.
+Proof.
+  preprocess.
+  eexists.
+  Time ensatz.
+Qed.
+
+Goal forall a b : Z, (a mod - b) mod b = a mod b.
+Proof.
+  preprocess.
+  eexists.
+  Time ensatz.
+Qed.
+
+Goal forall a b m : Z, (a - b) mod m = 0%Z -> a mod m = b mod m.
+Proof.
+  preprocess.
+  eexists.
   Time ensatz.
 Qed.
 
@@ -415,7 +475,11 @@ Goal forall n x y : Z, (0 <> n) /\ (x ^ n | y) -> (x | y).
   - ensatz.
 Qed.
 
-Require Import Reals RNsatz.
+(* *)
+(*      Examples with Reals *)
+(* *)
+
+From Stdlib Require Import Reals RNsatz.
 
 Definition div(a b: R):= exists k: R, b = k*a.
 

--- a/theories/ZArith/ZNsatz.v
+++ b/theories/ZArith/ZNsatz.v
@@ -1,5 +1,6 @@
-From Stdlib Require Import BinInt Lia NsatzTactic.
+From Stdlib Require Import BinInt Lia NsatzTactic ENsatzTactic.
 Export (ltac.notations) NsatzTactic.
+Export (ltac.notations) ENsatzTactic.
 
 (** Make use of [lia] in [nsatz] *)
 Ltac nsatz_internal_lia ::= lia.

--- a/theories/nsatz/ENsatzTactic.v
+++ b/theories/nsatz/ENsatzTactic.v
@@ -1,0 +1,530 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(*
+ Tactic ensatz: proofs of polynomials equalities in an integral domain
+ (commutative ring without zero divisor) with existential quantifier.
+
+ Examples: see test-suite/success/ENsatz.v
+
+*)
+
+From Stdlib Require Import BinPos.
+From Stdlib Require Import BinList.
+From Stdlib Require Import BinNat.
+From Stdlib Require Import BinInt.
+From Stdlib Require Import Ncring.
+From Stdlib Require Import NsatzTactic.
+
+Section ensatz.
+
+  Context {R:Type}`{Rid:Integral_domain R}.
+
+  Local Fixpoint LTType (A : Type) (l : list A) {struct l} : Type :=
+    match l with
+    | nil => unit
+    |  _ :: l0 =>  (R * LTType A l0)%type
+    end.
+
+  Local Fixpoint Cond0
+    (A : Type) (Interp : A -> R) (l : list A) {struct l} : (LTType A l -> R) :=
+    match l return (LTType A l -> R) with
+    | nil => (fun _ => ring0)
+    | a :: l0 => (fun n => add (mul (fst n) (Interp a))
+                        (Cond0 A Interp l0 (snd n)))
+    end.
+
+  Local Definition mk_Cond0 (A : Type) (Interp : A -> R) (l : list A) (v : R) :=
+    exists n, (v == Cond0 A Interp l n).
+
+  Local Fixpoint ring0_tuple (A :Type) (l: list A) : LTType A l :=
+    match l return (LTType A l) with
+    | nil => tt
+    | a :: q => (ring0, ring0_tuple A q)
+    end.
+
+  Local Fixpoint add_coef
+    (A : Type)
+    (Interp : A -> R)
+    (l: list A)  (a : list A)
+    (c : R) {struct l} : (LTType A l -> LTType A l) :=
+    match l, a return  (LTType A l -> LTType A l) with
+    | nil, _ => (fun _ => tt)
+    | _, nil => (fun x => x)
+    | h :: q , hx :: qx =>
+        let coef := c * (Interp hx) in
+        fun x => (coef + fst x, add_coef A Interp q qx c (snd x))
+    end.
+
+  Local Definition PhiR := @PhiR R ring0 ring1 add mul opp.
+
+  Local Lemma factories_compute_list :
+    forall lla l lpe lq,
+      mk_Cond0 PolZ (PhiR l) lpe
+        (PhiR l (mult_l lq (compute_list lla lpe))).
+  Proof.
+    unfold mk_Cond0.
+    induction lla.
+    - induction lpe.
+      + destruct lq;simpl;exists tt; reflexivity.
+      + intros;simpl.
+        destruct lq.
+        * simpl.
+          simpl in IHlpe.
+          specialize (IHlpe nil) as (x,H).
+          exists (ring0,x).
+          rewrite <- H.
+          cring.
+        * simpl.
+          simpl in IHlpe.
+          specialize (IHlpe lq) as (x, H).
+          exists (PhiR l (norm p),x);unfold PhiR.
+          rewrite  PolZadd_correct.
+          rewrite PolZmul_correct.
+          rewrite <- H.
+          cring.
+    - intros. simpl.
+      specialize (IHlla l (mult_l a lpe :: lpe) lq).
+      destruct IHlla.
+      simpl in H.
+      exists (add_coef PolZ (PhiR l) lpe (map norm a) (fst x) (snd x)).
+      unfold PhiR. rewrite H. clear H.
+      destruct x.
+      simpl.
+      generalize dependent lpe.
+      induction a.
+      + intros; destruct lpe; cring.
+      + intros.
+        destruct lpe;[ cring |].
+        simpl. unfold PhiR.
+        rewrite PolZadd_correct.
+        rewrite PolZmul_correct.
+        specialize (IHa lpe (snd l0)).
+        rewrite <- IHa.
+        cring.
+  Qed.
+
+  (* The type of the existential *)
+
+  Local Fixpoint LTEType (A : Type) (l : list (bool * A)) {struct l} : Type :=
+    match l with
+    | nil => unit
+    | (true, _) :: l0 =>  (R * LTEType A l0)%type
+    | (false,_)  :: l0 =>  LTEType A l0
+    end.
+
+  Local Fixpoint btype_to_ftype
+    (A B : Type)
+    (norm :  A -> B)
+    (l: list (bool*A)) {struct l} : (LTType B (map norm (map snd l)) -> LTEType A l) :=
+    match l return  (LTType B (map norm (map snd l)) -> LTEType A l) with
+    | nil => fun _ => tt
+    | (true,a) :: q =>  fun x => (fst x, btype_to_ftype A B norm  q (snd x))
+    | (false,a) :: q =>  fun x => (btype_to_ftype A B norm q (snd x))
+    end.
+
+  (* For the assumptions *)
+
+  Local Fixpoint mk_HCond0 (A : Type) (Interp : A -> R) (l : list (bool * A)) {struct l} : Prop :=
+    match l with
+    | nil => True
+    | (true, a) :: l0 => (mk_HCond0 A Interp l0)
+    | (false, a) :: l0 => ((Interp a) == 0) /\ (mk_HCond0 A Interp l0)
+    end.
+
+  (* For the conclusion *)
+
+  Local Fixpoint GCond0 (A : Type) (Interp : A -> R) (l : list (bool * A))
+    {struct l} : (LTEType A l -> R) :=
+    match l return (LTEType A l -> R) with
+    | nil => (fun _ => ring0)
+    | (true, a) :: l0 => (fun n => add (mul (fst n) (Interp a))
+                                (GCond0 A Interp l0 (snd n)))
+    | (false, a) :: l0 => GCond0 A Interp l0
+    end.
+
+  Local Definition mk_GCond0 (A : Type) (Interp : A -> R) (l : list (bool * A)) (v : R) :=
+    exists n, (v == GCond0 A Interp l n).
+
+  Local Lemma check_correct_exists :
+    forall l lpe qe lci lq ,
+      check (map snd lpe) qe (lci,lq) = true ->
+      mk_HCond0 PEZ (PEevalR l) lpe ->
+      mk_GCond0 PEZ (PEevalR l) lpe (PEevalR l qe).
+  Proof.
+    unfold check;intros l lpe qe lla lq H2 H1.
+    apply PolZeq_correct with (l:=l) in H2.
+    unfold mk_GCond0.
+    specialize (factories_compute_list lla l (map norm (map snd lpe)) lq) as H.
+    unfold mk_Cond0 in H. destruct H.
+    rewrite H in H2.
+    clear H.
+    exists (btype_to_ftype PEZ PolZ norm lpe x).
+    rewrite norm_correct.
+    rewrite H2.
+    clear H2.
+    induction lpe.
+    - cring.
+    - destruct a.
+      destruct b.
+      + simpl in H1.
+        destruct x.
+        specialize (IHlpe l0 H1).
+        simpl.
+        rewrite IHlpe.
+        rewrite norm_correct.
+        reflexivity.
+      + destruct H1.
+        destruct x.
+        specialize (IHlpe l0 H0).
+        simpl.
+        rewrite IHlpe.
+        unfold PhiR.
+        rewrite <- norm_correct.
+        rewrite H.
+        cring.
+  Qed.
+
+End ensatz.
+
+Module Mk_exists.
+
+  Local Ltac mk_tuple R l f :=
+    match l with
+    | (?a :: ?h) =>
+        let t := mk_tuple R h f in
+        constr:((t, f a))
+    | (?a1 :: ?a2 :: @nil R) => constr:((f a2,f a1))
+    end.
+
+  Local Ltac destr_tuple R l f :=
+    match goal with
+    | x : (R * ?A)%type |- _ =>
+        let z := fresh "z" in
+        destruct x as [z x];
+        let l := constr:(z :: l) in
+        destr_tuple R l f
+    | x : (unit)%type |- _ =>
+        let l := eval compute in (l) in
+        let t := mk_tuple R l f in
+        exists t
+   end.
+
+  Ltac mk_exists R x f :=
+    match goal with
+    | x : (R * unit)%type |- _ =>
+        let z := fresh "z" in
+        destruct x as [z x]; exists (f z)
+    | x : (R * ?A)%type |- _ => destr_tuple R constr:(@nil R) f
+    end.
+
+End Mk_exists.
+
+Module Mk_pl.
+
+  Local Fixpoint set_false (l: list (PExpr Z)) :=
+    match l with
+    | nil => nil
+    | h :: q => (false, h) :: (set_false q)
+    end.
+
+  Local Fixpoint set_true (l: list (PExpr Z)) :=
+    match l with
+    | nil => nil
+    | h :: q => (true, h) :: (set_true q)
+    end.
+
+  Ltac mk_pl lp21 n :=
+    let lp21 := eval compute in (List.rev lp21) in
+    let hd   := eval compute in (firstn n lp21) in
+    let hdt  := eval compute in (set_true hd) in
+    let tl   := eval compute in (skipn n lp21) in
+    let tlf  := eval compute in (set_false tl) in
+    let pl   := eval compute in (hdt ++ tlf) in
+    eval compute in (List.rev pl).
+
+End Mk_pl.
+
+Local Ltac ensatz_solve cr R p2 lp2 n fv info :=
+  let p21 := fresh "p21" in
+  let lp21 := fresh "lp21" in
+  let n21 := fresh "n21" in
+  let lv := fresh "lv" in
+  set (p21:=p2); set (lp21:=lp2); set (n21:= n); set(lv := fv);
+  (*We want r to be 1, so we set radicalmax to 1*)
+  NsatzTactic.nsatz_call 1%N info 0%Z p2 lp2
+    ltac:(fun c r lq lci =>
+            let Hg := fresh "Hg" in
+            let c21 := fresh "c" in
+            set (c21 := c);
+            let p211 := constr: (PEmul c p21) in
+            (*If c is not 1/-1, this assert should fail*)
+            assert (Hg:check lp21 p211 (lci,lq) = true);
+            [vm_compute; reflexivity |];
+            let pl := Mk_pl.mk_pl lp21 n in
+            assert (Hg2: mk_HCond0 PEZ (PEevalR lv) pl);
+            [repeat (split;[assumption|idtac]); exact I|];
+            generalize (@check_correct_exists
+                          _ _ _ _ _ _ _ _ _ _ _
+                          lv pl p211 lci lq Hg Hg2);
+            unfold mk_GCond0;
+            let x := fresh "x" in
+            let H1 := fresh "H" in
+            intros [x H1];
+            cbv delta [LTEType]
+              iota beta match in x;
+            match c with
+            | PEc((-1)%Z) => Mk_exists.mk_exists R x constr:(fun x:R => -x);
+                         symmetry in H1
+            | PEc(1%Z) => Mk_exists.mk_exists R x constr:(fun x:R => x)
+            end;
+            cbv delta [PEevalR GCond0
+                         Ring_polynom.PEeval
+                         gen_phiZ gen_phiPOS
+                         InitialRing.gen_phiZ
+                         InitialRing.gen_phiPOS
+                         BinList.nth
+                         jump nth lv p21 fst snd hd]
+              iota beta match in H1;
+              repeat unfold snd;
+              repeat unfold fst;
+              apply NsatzTactic.psos_r1b;
+              NsatzTactic.equalities_to_goal cr;
+              intros <-; cring ).
+
+Module Reifi.
+
+  Inductive Var {A: Type}: Type :=
+  | mRef: A -> Var
+  | fstVar :forall B,  @Var (A*B) -> @Var A
+  | sndVar : forall B, @Var (B*A) -> @Var A.
+
+  Local Ltac reify_evar_aux term :=
+    match term with
+    | (fun e => fst (@?P e)) =>
+        let term' := reify_evar_aux P in
+        constr:(fun x => @fstVar _ _ (term' x))
+    | (fun e => snd (@?P e)) =>
+        let term' := reify_evar_aux P in
+        constr:(fun x => @sndVar _ _ (term' x))
+    | (fun e:?T => e) => constr:(fun e :T => mRef e)
+    end.
+
+  Inductive MPoly {R: Type}: Type:=
+  | Poly : MPoly -> (PExpr Z) -> @Var R -> MPoly
+  | Pc : (PExpr Z) -> MPoly.
+
+  Local Ltac reify_evar R term :=
+    match term with
+    | (fun e => fst _) =>
+        let term' := reify_evar_aux term in
+        constr:(fun e' => @Poly R (@Pc R (PEc 0%Z)) (PEc 1%Z) (term' e'))
+    | (fun e => snd _) =>
+        let term' := reify_evar_aux term in
+        constr:(fun e' => @Poly R (@Pc R (PEc 0%Z)) (PEc 1%Z) (term' e'))
+    | (fun e:?T => e) =>  constr:(fun e':T => @Poly T (@Pc T (PEc 0%Z)) (PEc 1%Z) (mRef e'))
+    end.
+
+  Local Fixpoint mult_mpoly {A: Type} (c : PExpr Z) (p : @MPoly A) : @MPoly A :=
+    match p with
+    | Pc e => Pc (PEmul e c)
+    | Poly p e v => Poly (mult_mpoly c p) (PEmul e c) v
+    end.
+
+  Local Fixpoint equal {A1 A2: Type} (v1 : @Var A1) (v2 : @Var A2): comparison :=
+    match v1, v2 with
+    | mRef _, mRef _ => Eq
+    | fstVar _ v1, fstVar _ v2 => equal v1 v2
+    | sndVar _ v1, sndVar _ v2 => equal v1 v2
+    | fstVar _ _, sndVar _ _ => Gt
+    | sndVar _ _, fstVar _ _ => Lt
+    | _, mRef _ => Gt
+    | mRef _, _ => Lt
+    end.
+
+  Inductive Monom {R: Type}: Type:=
+  | Mon : (PExpr Z) -> @Var R -> Monom
+  | Monc : (PExpr Z) -> Monom.
+
+  Local Fixpoint add_monom_poly {A: Type} (p: @MPoly A) (m: @Monom A) :=
+    match p with
+    | Pc e1 =>
+        match m with
+        | Monc e2 => Pc (PEadd e1 e2)
+        | Mon e2 v => Poly p e2 v
+        end
+    | Poly p' e1 v1 =>
+        match m with
+        | Monc e2 => Poly (add_monom_poly p' m) e1 v1
+        | Mon e2 v2 =>
+            match equal v1 v2 with
+            | Eq => Poly p' (PEadd e1 e2) v1
+            | Gt => Poly (add_monom_poly p' m) e1 v1
+            | Lt => Poly p e2 v2
+            end
+        end
+    end.
+
+  Local Fixpoint add_mpoly {A: Type} (p1 p2 : @MPoly A) : @MPoly A :=
+    match p1 with
+    | Pc e1 => add_monom_poly p2 (Monc e1)
+    | Poly p1' e1 v1 => add_mpoly p1' (add_monom_poly p2 (Mon e1 v1))
+    end.
+
+  Local Fixpoint opp_mpoly {A: Type} (p: @MPoly A) : @MPoly A :=
+    match p with
+    | Pc e => Pc (PEopp e)
+    | Poly p e v => Poly (opp_mpoly p) (PEopp e) v
+    end.
+
+  Local Ltac reify R Tring lvar term:=
+    match open_constr:((Tring, term)) with
+    | (Ring (T:=?R) (add:=?add) (mul:=?mul) (sub:=?sub),
+        (fun e1 => ?op (@?E1 e1) (@?E2 e1))) =>
+        let _ := match goal with _ => convert add op end in
+        let E1' := reify R Tring lvar E1 in
+        let E2' := reify R Tring lvar E2 in
+        constr:(fun x => add_mpoly (E1' x) (E2' x))
+    | (Ring (T:=?R) (add:=?add) (mul:=?mul) (sub:=?sub),
+        (fun e1 => ?op (@?E1 e1) (@?E2 e1))) =>
+        let _ := match goal with _ => convert sub op end in
+        let E1' := reify R Tring lvar E1 in
+        let E2' := reify R Tring lvar E2 in
+        constr:(fun x => add_mpoly (E1' x) (opp_mpoly (E2' x)))
+    | (Ring (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
+         (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp),
+        (fun e1 => ?op ?E (@?E1 e1))) =>
+        let _ := match goal with _ => convert mul op end in
+        let E1' := reify R Tring lvar E1 in
+        let E' := reify_term R ring0 ring1 add mul sub opp lvar E in
+        constr:(fun x => mult_mpoly E' (E1' x))
+    | (Ring (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
+         (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp),
+        (fun e1 => ?op (@?E1 e1) ?E)) =>
+        let _ := match goal with _ => convert mul op end in
+        let E1' := reify R Tring lvar E1 in
+        let E' := reify_term R ring0 ring1 add mul sub opp lvar E in
+        constr:(fun x => mult_mpoly E' (E1' x))
+    | (_, (fun e => @?E e)) => reify_evar R E
+    | (Ring (T:=?R) (opp:=?opp), (fun e => ?op (@?E e))) =>
+        let _ := match goal with _ => convert opp op end in
+        let E' := reify_evar R E in
+        constr:(fun x => opp_mpoly (E' x))
+    | (Ring (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
+         (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp),
+        (fun _:?T => ?E)) =>
+        let E' := reify_term R ring0 ring1 add mul sub opp lvar E in
+        constr:(fun _:T => @Pc R E')
+    end.
+
+  Local Fixpoint get_coef {A:Type} (p: @MPoly A) :=
+    match p with
+    | Pc e => e :: nil
+    | Poly p e v => e :: get_coef p
+    end.
+
+  Local Definition coef {A R:Type} (p: A -> @MPoly R) :=
+    fun x => get_coef (p x).
+
+  Local Definition merge {A R:Type} (p1 p2: A -> @MPoly R) :=
+    fun x => add_mpoly (p1 x) (opp_mpoly (p2 x)).
+
+  Ltac reify_goal  :=
+    match goal with
+    | |- @ex _ (fun e1 : _ => @eq ?R (@?P1 e1) (@?P2 e1)) =>
+        let lvar := open_constr:(_ :> list R) in
+        let R_ring := constr:(_ :> Ring (T:=R)) in
+        let Tring := type of R_ring in
+        let xl := reify R Tring lvar P1 in
+        let xr := reify R Tring lvar P2 in
+        let x := eval cbv delta
+                   [merge coef
+                      get_coef
+                      add_mpoly
+                      mult_mpoly
+                      add_monom_poly
+                      equal
+                      opp_mpoly]
+                   beta iota in (coef (merge xr xl))
+          in
+          constr:((lvar,x))
+    end.
+
+End Reifi.
+
+Local Ltac reify_h lv lb :=
+  match lb with
+  | @nil ?R =>
+      let _ := match goal with _ => close_varlist lv end in
+      constr:((lv, (@nil (PExpr Z))))
+  | @cons ?R _ _ =>
+      let R_ring := constr:(_ :> Ring (T:=R)) in
+      list_reifyl R_ring lv lb
+ end.
+
+Local Ltac hterm R g :=
+    match g with
+    | (exists _: _, _ ) => constr:((@nil R))
+    | ?b1 == ?b2 -> ?g => let l := hterm R g in
+                         constr:((b1 :: l))
+    end.
+
+Lemma efactor:
+  forall A B P,  (exists x : A * B, P (fst x) (snd x)) -> (exists x : A, exists y: B, P x y).
+Proof.
+  intros A B P [x H].  eauto.
+Qed.
+
+Ltac nsatz_guess_domain :=
+  let eq := match goal with | |- @ex _ (fun e1 : _ => ?eq _ _ ) => eq end in
+  let di := lazymatch open_constr:(ltac:(typeclasses eauto):Integral_domain (ring_eq:=eq)) with?di => di end in
+  let __ := match di with _ => assert_fails (is_evar di) end in
+  di.
+
+Local Ltac ensatz_default info :=
+  intros;
+  repeat apply efactor;
+  let di := nsatz_guess_domain in
+  let r := lazymatch type of di with Integral_domain(R:=?r) => r end in
+  let cr := lazymatch type of di with Integral_domain(Rcr:=?cr) => cr end in
+  match goal with
+  | |- @ex _ (fun e1 : _ => @eq ?R (@?P1 e1) (@?P2 e1)) =>
+      match Reifi.reify_goal with
+      | (?lvar, (fun _: _ => ?x)) =>
+          let b := eval cbv delta [List.last] iota beta match
+                   in (List.last x (PEc 0%Z))
+          in
+          let b := constr: (PEopp b) in
+          let l := constr: (List.removelast x) in
+          let n := eval compute in (List.length l) in
+          repeat NsatzTactic.equalities_to_goal cr;
+          match goal with
+           |- ?g =>
+             let lb := hterm R g in
+             intros;
+             match reify_h lvar lb with
+             | (?fv, ?le) =>
+                let l := constr: (List.rev_append le l) in
+                let le := constr: (b :: l) in
+                let lpol := eval compute in le in
+                match lpol with
+                 | ?p2::?lp2 => ensatz_solve cr R p2 lp2 n fv info
+                 | ?g => idtac "polynomial not in the ideal"
+                 end
+             end
+        end
+    end
+end.
+
+Tactic Notation "ensatz" := ensatz_default 1%Z.
+
+Tactic Notation "ensatz" "with"
+ "strategy" ":=" constr(info) :=
+  ensatz_default info.

--- a/theories/nsatz/ENsatzTactic.v
+++ b/theories/nsatz/ENsatzTactic.v
@@ -10,7 +10,8 @@
 
 (*
  Tactic ensatz: proofs of polynomials equalities in an integral domain
- (commutative ring without zero divisor) with existential quantifier.
+ (commutative ring without zero divisor) with existential quantifier or
+ existential variables.
 
  Examples: see test-suite/success/ENsatz.v
 
@@ -41,9 +42,6 @@ Section ensatz.
                         (Cond0 A Interp l0 (snd n)))
     end.
 
-  Local Definition mk_Cond0 (A : Type) (Interp : A -> R) (l : list A) (v : R) :=
-    exists n, (v == Cond0 A Interp l n).
-
   Local Fixpoint ring0_tuple (A :Type) (l: list A) : LTType A l :=
     match l return (LTType A l) with
     | nil => tt
@@ -65,48 +63,61 @@ Section ensatz.
 
   Local Definition PhiR := @PhiR R ring0 ring1 add mul opp.
 
+  Local Fixpoint certi_aux
+    (Interp : PolZ -> R)
+    (lpe: list PolZ) (lq: list PEZ): LTType PolZ lpe :=
+    match lpe, lq return (LTType PolZ lpe) with
+    |  nil, _ => tt
+    |  h::q, nil=> (ring0, certi_aux Interp q lq)
+    |  h1::q1, h2::q2=> (Interp (norm h2), certi_aux Interp q1 q2 )
+    end.
+
+  Local Fixpoint certi
+    (Interp : PolZ -> R)
+    (lla : list (list PEZ)) (lpe: list PolZ) (lq: list PEZ)
+    : LTType PolZ lpe :=
+    match lla return (LTType PolZ lpe) with
+    | nil => certi_aux Interp lpe lq
+    | h::q =>
+        let l := certi Interp q ((mult_l h lpe) :: lpe) lq in
+        add_coef PolZ Interp lpe (map norm h) (fst l) (snd l)
+    end.
+
   Local Lemma factories_compute_list :
     forall lla l lpe lq,
-      mk_Cond0 PolZ (PhiR l) lpe
-        (PhiR l (mult_l lq (compute_list lla lpe))).
+      (PhiR l (mult_l lq (compute_list lla lpe))) ==
+        Cond0 PolZ (PhiR l) lpe (certi (PhiR l) lla lpe lq).
   Proof.
-    unfold mk_Cond0.
     induction lla.
     - induction lpe.
-      + destruct lq;simpl;exists tt; reflexivity.
-      + intros;simpl.
-        destruct lq.
-        * simpl.
-          simpl in IHlpe.
-          specialize (IHlpe nil) as (x,H).
-          exists (ring0,x).
+      + destruct lq;simpl; reflexivity.
+      + destruct lq;simpl; simpl in IHlpe.
+        * specialize (IHlpe nil) as H.
           rewrite <- H.
           cring.
-        * simpl.
-          simpl in IHlpe.
-          specialize (IHlpe lq) as (x, H).
-          exists (PhiR l (norm p),x);unfold PhiR.
+        * specialize (IHlpe lq) as H.
+          unfold PhiR.
           rewrite  PolZadd_correct.
           rewrite PolZmul_correct.
           rewrite <- H.
           cring.
     - intros. simpl.
-      specialize (IHlla l (mult_l a lpe :: lpe) lq).
-      destruct IHlla.
+      specialize (IHlla l (mult_l a lpe :: lpe) lq) as H.
       simpl in H.
-      exists (add_coef PolZ (PhiR l) lpe (map norm a) (fst x) (snd x)).
+      remember (fst (certi (PhiR l) lla (mult_l a lpe :: lpe) lq)) as r.
+      remember (snd (certi (PhiR l) lla (mult_l a lpe :: lpe) lq)) as l0.
+      clear Heql0. clear Heqr.
       unfold PhiR. rewrite H. clear H.
-      destruct x.
-      simpl.
+      generalize dependent l0.
       generalize dependent lpe.
       induction a.
-      + intros; destruct lpe; cring.
+      + intros;destruct lpe; simpl; cring.
       + intros.
         destruct lpe;[ cring |].
         simpl. unfold PhiR.
         rewrite PolZadd_correct.
         rewrite PolZmul_correct.
-        specialize (IHa lpe (snd l0)).
+        specialize (IHa lpe).
         rewrite <- IHa.
         cring.
   Qed.
@@ -123,7 +134,8 @@ Section ensatz.
   Local Fixpoint btype_to_ftype
     (A B : Type)
     (norm :  A -> B)
-    (l: list (bool*A)) {struct l} : (LTType B (map norm (map snd l)) -> LTEType A l) :=
+    (l: list (bool*A))
+    {struct l} : (LTType B (map norm (map snd l)) -> LTEType A l) :=
     match l return  (LTType B (map norm (map snd l)) -> LTEType A l) with
     | nil => fun _ => tt
     | (true,a) :: q =>  fun x => (fst x, btype_to_ftype A B norm  q (snd x))
@@ -132,7 +144,8 @@ Section ensatz.
 
   (* For the assumptions *)
 
-  Local Fixpoint mk_HCond0 (A : Type) (Interp : A -> R) (l : list (bool * A)) {struct l} : Prop :=
+  Local Fixpoint mk_HCond0
+    (A : Type) (Interp : A -> R) (l : list (bool * A)) {struct l} : Prop :=
     match l with
     | nil => True
     | (true, a) :: l0 => (mk_HCond0 A Interp l0)
@@ -150,40 +163,39 @@ Section ensatz.
     | (false, a) :: l0 => GCond0 A Interp l0
     end.
 
-  Local Definition mk_GCond0 (A : Type) (Interp : A -> R) (l : list (bool * A)) (v : R) :=
-    exists n, (v == GCond0 A Interp l n).
+  Local Definition cert l (lpe: list (prod bool PEZ)) lci lq:=
+    let p := certi (PhiR l) lci (map norm (map snd lpe)) lq in
+    btype_to_ftype PEZ PolZ norm lpe p.
 
-  Local Lemma check_correct_exists :
+  Local Lemma check_correct:
     forall l lpe qe lci lq ,
       check (map snd lpe) qe (lci,lq) = true ->
       mk_HCond0 PEZ (PEevalR l) lpe ->
-      mk_GCond0 PEZ (PEevalR l) lpe (PEevalR l qe).
+      (PEevalR l qe) == GCond0 PEZ (PEevalR l) lpe (cert l lpe lci lq).
   Proof.
+    unfold cert.
     unfold check;intros l lpe qe lla lq H2 H1.
     apply PolZeq_correct with (l:=l) in H2.
-    unfold mk_GCond0.
     specialize (factories_compute_list lla l (map norm (map snd lpe)) lq) as H.
-    unfold mk_Cond0 in H. destruct H.
     rewrite H in H2.
     clear H.
-    exists (btype_to_ftype PEZ PolZ norm lpe x).
     rewrite norm_correct.
     rewrite H2.
     clear H2.
+    remember (certi (PhiR l) lla (map norm (map snd lpe)) lq) as x.
+    clear Heqx.
     induction lpe.
     - cring.
     - destruct a.
       destruct b.
       + simpl in H1.
-        destruct x.
-        specialize (IHlpe l0 H1).
+        specialize (IHlpe H1 (snd x)).
         simpl.
         rewrite IHlpe.
         rewrite norm_correct.
         reflexivity.
       + destruct H1.
-        destruct x.
-        specialize (IHlpe l0 H0).
+        specialize (IHlpe H0 (snd x)).
         simpl.
         rewrite IHlpe.
         unfold PhiR.
@@ -192,40 +204,16 @@ Section ensatz.
         cring.
   Qed.
 
+  Local Lemma check_correct_exists :
+    forall l lpe qe lci lq ,
+      check (map snd lpe) qe (lci,lq) = true ->
+      mk_HCond0 PEZ (PEevalR l) lpe ->
+      exists n, ((PEevalR l qe) == GCond0 PEZ (PEevalR l) lpe n).
+  Proof.
+    intros * H1 H2; eexists; apply check_correct;[ apply H1 | assumption].
+  Qed.
+
 End ensatz.
-
-Module Mk_exists.
-
-  Local Ltac mk_tuple R l f :=
-    match l with
-    | (?a :: ?h) =>
-        let t := mk_tuple R h f in
-        constr:((t, f a))
-    | (?a1 :: ?a2 :: @nil R) => constr:((f a2,f a1))
-    end.
-
-  Local Ltac destr_tuple R l f :=
-    match goal with
-    | x : (R * ?A)%type |- _ =>
-        let z := fresh "z" in
-        destruct x as [z x];
-        let l := constr:(z :: l) in
-        destr_tuple R l f
-    | x : (unit)%type |- _ =>
-        let l := eval compute in (l) in
-        let t := mk_tuple R l f in
-        exists t
-   end.
-
-  Ltac mk_exists R x f :=
-    match goal with
-    | x : (R * unit)%type |- _ =>
-        let z := fresh "z" in
-        destruct x as [z x]; exists (f z)
-    | x : (R * ?A)%type |- _ => destr_tuple R constr:(@nil R) f
-    end.
-
-End Mk_exists.
 
 Module Mk_pl.
 
@@ -252,212 +240,446 @@ Module Mk_pl.
 
 End Mk_pl.
 
-Local Ltac ensatz_solve cr R p2 lp2 n fv info :=
-  let p21 := fresh "p21" in
-  let lp21 := fresh "lp21" in
-  let n21 := fresh "n21" in
-  let lv := fresh "lv" in
-  set (p21:=p2); set (lp21:=lp2); set (n21:= n); set(lv := fv);
-  (*We want r to be 1, so we set radicalmax to 1*)
-  NsatzTactic.nsatz_call 1%N info 0%Z p2 lp2
-    ltac:(fun c r lq lci =>
-            let Hg := fresh "Hg" in
-            let c21 := fresh "c" in
-            set (c21 := c);
-            let p211 := constr: (PEmul c p21) in
-            (*If c is not 1/-1, this assert should fail*)
-            assert (Hg:check lp21 p211 (lci,lq) = true);
-            [vm_compute; reflexivity |];
-            let pl := Mk_pl.mk_pl lp21 n in
-            assert (Hg2: mk_HCond0 PEZ (PEevalR lv) pl);
-            [repeat (split;[assumption|idtac]); exact I|];
-            generalize (@check_correct_exists
-                          _ _ _ _ _ _ _ _ _ _ _
-                          lv pl p211 lci lq Hg Hg2);
-            unfold mk_GCond0;
-            let x := fresh "x" in
-            let H1 := fresh "H" in
-            intros [x H1];
-            cbv delta [LTEType]
-              iota beta match in x;
-            match c with
-            | PEc((-1)%Z) => Mk_exists.mk_exists R x constr:(fun x:R => -x);
-                         symmetry in H1
-            | PEc(1%Z) => Mk_exists.mk_exists R x constr:(fun x:R => x)
-            end;
-            cbv delta [PEevalR GCond0
-                         Ring_polynom.PEeval
-                         gen_phiZ gen_phiPOS
-                         InitialRing.gen_phiZ
-                         InitialRing.gen_phiPOS
-                         BinList.nth
-                         jump nth lv p21 fst snd hd]
-              iota beta match in H1;
-              repeat unfold snd;
-              repeat unfold fst;
-              apply NsatzTactic.psos_r1b;
-              NsatzTactic.equalities_to_goal cr;
-              intros <-; cring ).
+Module Ensatz_solve.
 
-Module Reifi.
-
-  Inductive Var {A: Type}: Type :=
-  | mRef: A -> Var
-  | fstVar :forall B,  @Var (A*B) -> @Var A
-  | sndVar : forall B, @Var (B*A) -> @Var A.
-
-  Local Ltac reify_evar_aux term :=
-    match term with
-    | (fun e => fst (@?P e)) =>
-        let term' := reify_evar_aux P in
-        constr:(fun x => @fstVar _ _ (term' x))
-    | (fun e => snd (@?P e)) =>
-        let term' := reify_evar_aux P in
-        constr:(fun x => @sndVar _ _ (term' x))
-    | (fun e:?T => e) => constr:(fun e :T => mRef e)
+  Local Ltac mk_tuple R l f :=
+    match l with
+    | (?a :: ?h) =>
+        let t := mk_tuple R h f in
+        constr:((t, f a))
+    | (?a1 :: ?a2 :: @nil R) => constr:((f a2,f a1))
     end.
 
-  Inductive MPoly {R: Type}: Type:=
-  | Poly : MPoly -> (PExpr Z) -> @Var R -> MPoly
-  | Pc : (PExpr Z) -> MPoly.
-
-  Local Ltac reify_evar R term :=
-    match term with
-    | (fun e => fst _) =>
-        let term' := reify_evar_aux term in
-        constr:(fun e' => @Poly R (@Pc R (PEc 0%Z)) (PEc 1%Z) (term' e'))
-    | (fun e => snd _) =>
-        let term' := reify_evar_aux term in
-        constr:(fun e' => @Poly R (@Pc R (PEc 0%Z)) (PEc 1%Z) (term' e'))
-    | (fun e:?T => e) =>  constr:(fun e':T => @Poly T (@Pc T (PEc 0%Z)) (PEc 1%Z) (mRef e'))
-    end.
-
-  Local Fixpoint mult_mpoly {A: Type} (c : PExpr Z) (p : @MPoly A) : @MPoly A :=
-    match p with
-    | Pc e => Pc (PEmul e c)
-    | Poly p e v => Poly (mult_mpoly c p) (PEmul e c) v
-    end.
-
-  Local Fixpoint equal {A1 A2: Type} (v1 : @Var A1) (v2 : @Var A2): comparison :=
-    match v1, v2 with
-    | mRef _, mRef _ => Eq
-    | fstVar _ v1, fstVar _ v2 => equal v1 v2
-    | sndVar _ v1, sndVar _ v2 => equal v1 v2
-    | fstVar _ _, sndVar _ _ => Gt
-    | sndVar _ _, fstVar _ _ => Lt
-    | _, mRef _ => Gt
-    | mRef _, _ => Lt
-    end.
-
-  Inductive Monom {R: Type}: Type:=
-  | Mon : (PExpr Z) -> @Var R -> Monom
-  | Monc : (PExpr Z) -> Monom.
-
-  Local Fixpoint add_monom_poly {A: Type} (p: @MPoly A) (m: @Monom A) :=
-    match p with
-    | Pc e1 =>
-        match m with
-        | Monc e2 => Pc (PEadd e1 e2)
-        | Mon e2 v => Poly p e2 v
-        end
-    | Poly p' e1 v1 =>
-        match m with
-        | Monc e2 => Poly (add_monom_poly p' m) e1 v1
-        | Mon e2 v2 =>
-            match equal v1 v2 with
-            | Eq => Poly p' (PEadd e1 e2) v1
-            | Gt => Poly (add_monom_poly p' m) e1 v1
-            | Lt => Poly p e2 v2
-            end
-        end
-    end.
-
-  Local Fixpoint add_mpoly {A: Type} (p1 p2 : @MPoly A) : @MPoly A :=
-    match p1 with
-    | Pc e1 => add_monom_poly p2 (Monc e1)
-    | Poly p1' e1 v1 => add_mpoly p1' (add_monom_poly p2 (Mon e1 v1))
-    end.
-
-  Local Fixpoint opp_mpoly {A: Type} (p: @MPoly A) : @MPoly A :=
-    match p with
-    | Pc e => Pc (PEopp e)
-    | Poly p e v => Poly (opp_mpoly p) (PEopp e) v
-    end.
-
-  Local Ltac reify R Tring lvar term:=
-    match open_constr:((Tring, term)) with
-    | (Ring (T:=?R) (add:=?add) (mul:=?mul) (sub:=?sub),
-        (fun e1 => ?op (@?E1 e1) (@?E2 e1))) =>
-        let _ := match goal with _ => convert add op end in
-        let E1' := reify R Tring lvar E1 in
-        let E2' := reify R Tring lvar E2 in
-        constr:(fun x => add_mpoly (E1' x) (E2' x))
-    | (Ring (T:=?R) (add:=?add) (mul:=?mul) (sub:=?sub),
-        (fun e1 => ?op (@?E1 e1) (@?E2 e1))) =>
-        let _ := match goal with _ => convert sub op end in
-        let E1' := reify R Tring lvar E1 in
-        let E2' := reify R Tring lvar E2 in
-        constr:(fun x => add_mpoly (E1' x) (opp_mpoly (E2' x)))
-    | (Ring (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
-         (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp),
-        (fun e1 => ?op ?E (@?E1 e1))) =>
-        let _ := match goal with _ => convert mul op end in
-        let E1' := reify R Tring lvar E1 in
-        let E' := reify_term R ring0 ring1 add mul sub opp lvar E in
-        constr:(fun x => mult_mpoly E' (E1' x))
-    | (Ring (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
-         (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp),
-        (fun e1 => ?op (@?E1 e1) ?E)) =>
-        let _ := match goal with _ => convert mul op end in
-        let E1' := reify R Tring lvar E1 in
-        let E' := reify_term R ring0 ring1 add mul sub opp lvar E in
-        constr:(fun x => mult_mpoly E' (E1' x))
-    | (_, (fun e => @?E e)) => reify_evar R E
-    | (Ring (T:=?R) (opp:=?opp), (fun e => ?op (@?E e))) =>
-        let _ := match goal with _ => convert opp op end in
-        let E' := reify_evar R E in
-        constr:(fun x => opp_mpoly (E' x))
-    | (Ring (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
-         (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp),
-        (fun _:?T => ?E)) =>
-        let E' := reify_term R ring0 ring1 add mul sub opp lvar E in
-        constr:(fun _:T => @Pc R E')
-    end.
-
-  Local Fixpoint get_coef {A:Type} (p: @MPoly A) :=
-    match p with
-    | Pc e => e :: nil
-    | Poly p e v => e :: get_coef p
-    end.
-
-  Local Definition coef {A R:Type} (p: A -> @MPoly R) :=
-    fun x => get_coef (p x).
-
-  Local Definition merge {A R:Type} (p1 p2: A -> @MPoly R) :=
-    fun x => add_mpoly (p1 x) (opp_mpoly (p2 x)).
-
-  Ltac reify_goal  :=
+  Local Ltac destr_tuple R l f :=
     match goal with
-    | |- @ex _ (fun e1 : _ => @eq ?R (@?P1 e1) (@?P2 e1)) =>
-        let lvar := open_constr:(_ :> list R) in
-        let R_ring := constr:(_ :> Ring (T:=R)) in
-        let Tring := type of R_ring in
-        let xl := reify R Tring lvar P1 in
-        let xr := reify R Tring lvar P2 in
-        let x := eval cbv delta
-                   [merge coef
-                      get_coef
-                      add_mpoly
-                      mult_mpoly
-                      add_monom_poly
-                      equal
-                      opp_mpoly]
-                   beta iota in (coef (merge xr xl))
-          in
-          constr:((lvar,x))
+    | x : (R * ?A)%type |- _ =>
+        let z := fresh "z" in
+        destruct x as [z x];
+        let l := constr:(z :: l) in
+        destr_tuple R l f
+    | x : (unit)%type |- _ =>
+        let l := eval compute in (l) in
+        let t := mk_tuple R l f in
+        exists t
+     end.
+
+  Ltac mk_exists R x f :=
+    match goal with
+    | x : (R * unit)%type |- _ =>
+        let z := fresh "z" in
+        destruct x as [z x]; exists (f z)
+    | x : (R * ?A)%type |- _ =>
+        destr_tuple R constr:(@nil R) f
     end.
 
-End Reifi.
+  Ltac ensatz_solve cr R p2 lp2 n fv info :=
+    let p21 := fresh "p21" in
+    let lp21 := fresh "lp21" in
+    let n21 := fresh "n21" in
+    let lv := fresh "lv" in
+    set (p21:=p2); set (lp21:=lp2); set (n21:= n); set(lv := fv);
+    (*We want r to be 1, so we set radicalmax to 1*)
+    NsatzTactic.nsatz_call 1%N info 0%Z p2 lp2
+      ltac:(fun c r lq lci =>
+              let Hg := fresh "Hg" in
+              let c21 := fresh "c" in
+              set (c21 := c);
+              let p211 := constr: (PEmul c p21) in
+              let pl := Mk_pl.mk_pl lp21 n in
+              (*If c is not 1/-1, this assert should fail*)
+              assert (Hg:check lp21 p211 (lci,lq) = true);
+              [vm_compute; reflexivity |];
+              assert (Hg2: mk_HCond0 PEZ (PEevalR lv) pl);
+              [repeat (split;[assumption|idtac]); exact I|];
+              generalize (@check_correct_exists
+                            _ _ _ _ _ _ _ _ _ _ _
+                            lv pl p211 lci lq Hg Hg2);
+              let x := fresh "x" in
+              let H1 := fresh "H" in
+              intros [x H1];
+              cbv delta [LTEType] iota beta match in x;
+              match c with
+              | PEc((-1)%Z) => mk_exists R x constr:(fun x:R => -x);
+                              symmetry in H1
+              | PEc(1%Z) => mk_exists R x constr:(fun x:R => x)
+              end;
+              cbv delta
+                [PEevalR GCond0
+                   Ring_polynom.PEeval
+                   gen_phiZ gen_phiPOS
+                   InitialRing.gen_phiZ
+                   InitialRing.gen_phiPOS
+                   BinList.nth
+                   jump nth lv p21 fst snd hd]
+                iota beta match in H1;
+               repeat unfold snd;
+               repeat unfold fst;
+               apply NsatzTactic.psos_r1b;
+               NsatzTactic.equalities_to_goal cr;
+               intros <-; cring
+           ).
+
+  Module Reifi.
+
+    Inductive Var {A: Type}: Type :=
+    | mRef: A -> Var
+    | fstVar : forall B, @Var (A*B) -> @Var A
+    | sndVar : forall B, @Var (B*A) -> @Var A.
+
+    Local Ltac reify_evar_aux term :=
+      match term with
+      | (fun e => fst (@?P e)) =>
+          let term' := reify_evar_aux P in
+          constr:(fun x => @fstVar _ _ (term' x))
+      | (fun e => snd (@?P e)) =>
+          let term' := reify_evar_aux P in
+          constr:(fun x => @sndVar _ _ (term' x))
+      | (fun e:?T => e) => constr:(fun e :T => mRef e)
+      end.
+
+    Inductive MPoly {R: Type}: Type:=
+    | Poly : MPoly -> (PExpr Z) -> @Var R -> MPoly
+    | Pc : (PExpr Z) -> MPoly.
+
+    Local Ltac reify_evar R term :=
+      match term with
+      | (fun e => fst _) =>
+          let term' := reify_evar_aux term in
+          constr:(fun e' => @Poly R (@Pc R (PEc 0%Z)) (PEc 1%Z) (term' e'))
+      | (fun e => snd _) =>
+          let term' := reify_evar_aux term in
+          constr:(fun e' => @Poly R (@Pc R (PEc 0%Z)) (PEc 1%Z) (term' e'))
+      | (fun e:?T => e) =>
+          constr:(fun e':T => @Poly T (@Pc T (PEc 0%Z)) (PEc 1%Z) (mRef e'))
+      end.
+
+    Local Fixpoint mult_mpoly
+      {A: Type} (c : PExpr Z) (p : @MPoly A) : @MPoly A :=
+      match p with
+      | Pc e => Pc (PEmul e c)
+      | Poly p e v => Poly (mult_mpoly c p) (PEmul e c) v
+      end.
+
+    Local Fixpoint equal
+      {A1 A2: Type} (v1 : @Var A1) (v2 : @Var A2): comparison :=
+      match v1, v2 with
+      | mRef _, mRef _ => Eq
+      | fstVar _ v1, fstVar _ v2 => equal v1 v2
+      | sndVar _ v1, sndVar _ v2 => equal v1 v2
+      | fstVar _ _, sndVar _ _ => Gt
+      | sndVar _ _, fstVar _ _ => Lt
+      | _, mRef _ => Gt
+      | mRef _, _ => Lt
+      end.
+
+    Inductive Monom {R: Type}: Type:=
+    | Mon : (PExpr Z) -> @Var R -> Monom
+    | Monc : (PExpr Z) -> Monom.
+
+    Local Fixpoint add_monom_poly {A: Type} (p: @MPoly A) (m: @Monom A) :=
+      match p with
+      | Pc e1 =>
+          match m with
+          | Monc e2 => Pc (PEadd e1 e2)
+          | Mon e2 v => Poly p e2 v
+          end
+      | Poly p' e1 v1 =>
+          match m with
+          | Monc e2 => Poly (add_monom_poly p' m) e1 v1
+          | Mon e2 v2 =>
+              match equal v1 v2 with
+              | Eq => Poly p' (PEadd e1 e2) v1
+              | Gt => Poly (add_monom_poly p' m) e1 v1
+              | Lt => Poly p e2 v2
+              end
+          end
+      end.
+
+    Local Fixpoint add_mpoly {A: Type} (p1 p2 : @MPoly A) : @MPoly A :=
+      match p1 with
+      | Pc e1 => add_monom_poly p2 (Monc e1)
+      | Poly p1' e1 v1 => add_mpoly p1' (add_monom_poly p2 (Mon e1 v1))
+      end.
+
+    Local Fixpoint opp_mpoly {A: Type} (p: @MPoly A) : @MPoly A :=
+      match p with
+      | Pc e => Pc (PEopp e)
+      | Poly p e v => Poly (opp_mpoly p) (PEopp e) v
+      end.
+
+    Local Ltac reify R Tring lvar term:=
+      match open_constr:((Tring, term)) with
+      | (Ring (T:=?R) (add:=?add) (mul:=?mul) (sub:=?sub),
+          (fun e1 => ?op (@?E1 e1) (@?E2 e1))) =>
+          let _ := match goal with _ => convert add op end in
+          let E1' := reify R Tring lvar E1 in
+          let E2' := reify R Tring lvar E2 in
+          constr:(fun x => add_mpoly (E1' x) (E2' x))
+      | (Ring (T:=?R) (add:=?add) (mul:=?mul) (sub:=?sub),
+          (fun e1 => ?op (@?E1 e1) (@?E2 e1))) =>
+          let _ := match goal with _ => convert sub op end in
+          let E1' := reify R Tring lvar E1 in
+          let E2' := reify R Tring lvar E2 in
+          constr:(fun x => add_mpoly (E1' x) (opp_mpoly (E2' x)))
+      | (Ring (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
+           (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp),
+          (fun e1 => ?op ?E (@?E1 e1))) =>
+          let _ := match goal with _ => convert mul op end in
+          let E1' := reify R Tring lvar E1 in
+          let E' := reify_term R ring0 ring1 add mul sub opp lvar E in
+          constr:(fun x => mult_mpoly E' (E1' x))
+      | (Ring (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
+           (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp),
+          (fun e1 => ?op (@?E1 e1) ?E)) =>
+          let _ := match goal with _ => convert mul op end in
+          let E1' := reify R Tring lvar E1 in
+          let E' := reify_term R ring0 ring1 add mul sub opp lvar E in
+          constr:(fun x => mult_mpoly E' (E1' x))
+      | (_, (fun e => @?E e)) => reify_evar R E
+      | (Ring (T:=?R) (opp:=?opp), (fun e => ?op (@?E e))) =>
+          let _ := match goal with _ => convert opp op end in
+          let E' := reify_evar R E in
+          constr:(fun x => opp_mpoly (E' x))
+      | (Ring (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
+           (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp),
+          (fun _:?T => ?E)) =>
+          let E' := reify_term R ring0 ring1 add mul sub opp lvar E in
+          constr:(fun _:T => @Pc R E')
+      end.
+
+    Local Fixpoint get_coef {A:Type} (p: @MPoly A) :=
+      match p with
+      | Pc e => e :: nil
+      | Poly p e v => e :: get_coef p
+      end.
+
+    Local Definition coef {A R:Type} (p: A -> @MPoly R) :=
+      fun x => get_coef (p x).
+
+    Local Definition merge {A R:Type} (p1 p2: A -> @MPoly R) :=
+      fun x => add_mpoly (p1 x) (opp_mpoly (p2 x)).
+
+    Ltac reify_goal  :=
+      match goal with
+      | |- @ex _ (fun e1 : _ => @eq ?R (@?P1 e1) (@?P2 e1)) =>
+          let lvar := open_constr:(_ :> list R) in
+          let R_ring := constr:(_ :> Ring (T:=R)) in
+          let Tring := type of R_ring in
+          let xl := reify R Tring lvar P1 in
+          let xr := reify R Tring lvar P2 in
+          let x :=
+            eval cbv delta
+              [merge coef
+                 get_coef
+                 add_mpoly
+                 mult_mpoly
+                 add_monom_poly
+                 equal
+                 opp_mpoly]
+              beta iota in (coef (merge xr xl))
+           in
+           constr:((lvar,x))
+      end.
+
+  End Reifi.
+
+  Ltac hterm R g :=
+    match g with
+    | (exists _: _, _ ) => constr:((@nil R))
+    | ?b1 == ?b2 -> ?g =>
+        let l := hterm R g in
+        constr:((b1 :: l))
+    end.
+
+End Ensatz_solve.
+
+Module Eensatz_solve.
+
+  Local Ltac econstrain lv le z:=
+    match open_constr:((lv, le)) with
+    |((?h1, ?q1), @cons _ ?h2 ?q2) =>
+       assert (h2 = z * h1) by reflexivity;
+       econstrain q1 q2 z
+    | (_, _) => idtac
+    end.
+
+  Arguments Z.mul : simpl nomatch.
+
+  Ltac ensatz_solve p2 lp2 n fv vs info :=
+    let p21 := fresh "p21" in
+    let lp21 := fresh "lp21" in
+    let lv := fresh "lv" in
+    let lvs := fresh "lvs" in
+    set (p21:=p2);set (lp21:=lp2); set(lv := fv); set (lvs := vs);
+    (*We want r to be 1, so we set radicalmax to 1*)
+    NsatzTactic.nsatz_call 1%N info 0%Z p2 lp2
+      ltac:(fun c r lq lci =>
+              let Hg := fresh "Hg" in
+              let c21 := fresh "c" in
+              let p211 := constr: (PEmul c p21) in
+              let pl := Mk_pl.mk_pl lp21 n in
+              let cert :=  eval cbn in  (cert lv pl lci lq)  in
+              let y := eval simpl in (map (PEevalR lv) vs) in
+              match c with
+              | PEc ((-1)%Z) => econstrain cert y ((-1)%Z)
+              | PEc (1%Z) => econstrain cert y (1%Z)
+              end;
+              (*If c is not 1/-1, this assert should fail*)
+              assert (Hg:check lp21 p211 (lci,lq) = true);
+              [vm_compute; reflexivity |];
+              assert (Hg2: mk_HCond0 PEZ (PEevalR lv) pl);
+              [repeat (split;[assumption|idtac]); exact I|];
+              generalize (@check_correct
+                            _ _ _ _ _ _ _ _ _ _ _
+                            lv pl p211 lci lq Hg Hg2);
+              let H1 := fresh "H" in
+              intros H1; cbn in H1;revert H1;clear;nsatz
+           ).
+
+  Module Reifi.
+
+    Inductive MPoly: Type:=
+    | Poly : MPoly -> (PExpr Z) -> positive -> MPoly
+    | Pc : (PExpr Z) -> MPoly.
+
+    Local Fixpoint mult_mpoly (c : PExpr Z) (p : MPoly) : MPoly :=
+      match p with
+      | Pc e => Pc (PEmul e c)
+      | Poly p e v => Poly (mult_mpoly c p) (PEmul e c) v
+      end.
+
+    Inductive Monom: Type:=
+    | Mon : (PExpr Z) -> positive -> Monom
+    | Monc : (PExpr Z) -> Monom.
+
+    Local Fixpoint add_monom_poly (p: MPoly) (m: Monom) :=
+      match p with
+      | Pc e1 =>
+          match m with
+          | Monc e2 => Pc (PEadd e1 e2)
+          | Mon e2 v => Poly p e2 v
+          end
+      | Poly p' e1 v1 =>
+          match m with
+          | Monc e2 => Poly (add_monom_poly p' m) e1 v1
+          | Mon e2 v2 =>
+              match Pos.compare v1 v2 with
+              | Eq => Poly p' (PEadd e1 e2) v1
+              | Gt => Poly (add_monom_poly p' m) e1 v1
+              | Lt => Poly p e2 v2
+              end
+          end
+      end.
+
+    Local Fixpoint add_mpoly (p1 p2 : MPoly) : MPoly :=
+      match p1 with
+      | Pc e1 => add_monom_poly p2 (Monc e1)
+      | Poly p1' e1 v1 => add_mpoly p1' (add_monom_poly p2 (Mon e1 v1))
+      end.
+
+    Local Fixpoint opp_mpoly (p: @MPoly) : @MPoly :=
+      match p with
+      | Pc e => Pc (PEopp e)
+      | Poly p e v => Poly (opp_mpoly p) (PEopp e) v
+      end.
+
+    Local Ltac areify R Tring lvar term:=
+      match open_constr:((Tring, term)) with
+      | (Ring
+           (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
+           (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp), ?E) =>
+          let __ := match E with _ => is_ground E end in
+          let E' := reify_term R ring0 ring1 add mul sub opp lvar E in
+          constr:((@Pc E'))
+      | (Ring
+           (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
+           (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp), ?E) =>
+          let __ := match E with _ => is_evar E end in
+          let E' := reify_term R ring0 ring1 add mul sub opp lvar E in
+          let n :=
+            match E' with
+            | PEX _ ?n => n
+            end
+          in
+          constr:(@Poly (@Pc (PEc 0%Z)) (PEc 1%Z) n)
+      | (Ring
+           (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
+           (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp), ?op ?E1 ?E2) =>
+          let _ := match goal with _ => convert mul op end in
+          let _ := match E1 with _ => is_ground E1 end in
+          let _ := match E2 with _ => has_evar E2 end in
+          let E1' := reify_term R ring0 ring1 add mul sub opp lvar E1 in
+          let E2' := areify R Tring lvar E2 in
+          constr:(mult_mpoly E1' E2')
+      | (Ring
+           (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
+           (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp), ?op ?E1 ?E2) =>
+          let _ := match goal with _ => convert mul op end in
+          let _ := match E1 with _ => has_evar E1 end in
+          let _ := match E2 with _ => is_ground E2 end in
+          let E1' := areify R Tring lvar E1 in
+          let E2' := reify_term R ring0 ring1 add mul sub opp lvar E2 in
+          constr:(mult_mpoly E2' E1')
+      | (Ring
+           (T:=?R) (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp), ?op ?E1 ?E2) =>
+          let _ := match goal with _ => convert add op end in
+          let E1' := areify R Tring lvar E1 in
+          let E2' := areify R Tring lvar E2 in
+          constr:(add_mpoly E1' E2')
+      | (Ring (T:=?R) (add:=?add) (mul:=?mul) (sub:=?sub), ?op ?E1 ?E2) =>
+          let _ := match goal with _ => convert sub op end in
+          let E1' := areify R Tring lvar E1 in
+          let E2' := areify R Tring lvar E2 in
+          constr:(add_mpoly E1' (opp_mpoly E2'))
+      | (Ring (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
+           (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp), (?op ?E)) =>
+          let _ := match goal with _ => convert opp op end in
+          let _ := match E with _ => is_evar E end in
+          let E' := reify_term R ring0 ring1 add mul sub opp lvar E in
+          let n := match E' with
+                   | PEX _ ?n => n
+                   end
+          in
+          constr:(opp_mpoly(@Poly (@Pc (PEc 0%Z)) (PEc 1%Z) n))
+      end.
+
+    Local Fixpoint get_coef (p: @MPoly) :=
+      match p with
+      | Pc e => e :: nil
+      | Poly p e v => e :: get_coef p
+      end.
+
+    Local Fixpoint get_var (p: @MPoly) :=
+      match p with
+      | Pc e => nil
+      | Poly p e v => (PEX Z v) :: get_var p
+      end.
+
+    Ltac reify_goal  :=
+      match goal with
+      | |- @eq ?R ?E1 ?E2 =>
+          let lvar := open_constr:(_ :> list R) in
+          let R_ring := constr:(_ :> Ring (T:=R)) in
+          let Tring := type of R_ring in
+          let xl := areify R Tring lvar E1 in
+          let xr := areify R Tring lvar E2 in
+          let poly := eval vm_compute in (add_mpoly xr (opp_mpoly xl)) in
+          let x := eval vm_compute in (get_coef poly) in
+          let v := eval vm_compute in (get_var poly) in
+          constr:((lvar,x, v))
+      end.
+
+  End Reifi.
+
+  Ltac hterm R g :=
+    match g with
+    | ?b1 = ?b2 => constr:((@nil R))
+    | ?b1 == ?b2 -> ?g =>
+        let l := hterm R g in
+        constr:((b1 :: l))
+    end.
+
+End Eensatz_solve.
 
 Local Ltac reify_h lv lb :=
   match lb with
@@ -469,37 +691,65 @@ Local Ltac reify_h lv lb :=
       list_reifyl R_ring lv lb
  end.
 
-Local Ltac hterm R g :=
-    match g with
-    | (exists _: _, _ ) => constr:((@nil R))
-    | ?b1 == ?b2 -> ?g => let l := hterm R g in
-                         constr:((b1 :: l))
-    end.
+Ltac nsatz_guess_domain :=
+  let eq := match goal with
+            | |- @ex _ (fun e1 : _ => ?eq _ _ ) => eq
+            | |- ?eq _ _ => eq
+            end
+  in
+  let di :=
+    lazymatch
+      open_constr:(ltac:(typeclasses eauto):Integral_domain (ring_eq:=eq))
+    with?di => di end
+  in
+  let __ := match di with _ => assert_fails (is_evar di) end in
+  di.
 
 Lemma efactor:
   forall A B P,  (exists x : A * B, P (fst x) (snd x)) -> (exists x : A, exists y: B, P x y).
 Proof.
-  intros A B P [x H].  eauto.
+  intros A B P [x H]. eauto.
 Qed.
 
-Ltac nsatz_guess_domain :=
-  let eq := match goal with | |- @ex _ (fun e1 : _ => ?eq _ _ ) => eq end in
-  let di := lazymatch open_constr:(ltac:(typeclasses eauto):Integral_domain (ring_eq:=eq)) with?di => di end in
-  let __ := match di with _ => assert_fails (is_evar di) end in
-  di.
-
-Local Ltac ensatz_default info :=
+Ltac ensatz_default info :=
   intros;
   repeat apply efactor;
   let di := nsatz_guess_domain in
   let r := lazymatch type of di with Integral_domain(R:=?r) => r end in
   let cr := lazymatch type of di with Integral_domain(Rcr:=?cr) => cr end in
   match goal with
-  | |- @ex _ (fun e1 : _ => @eq ?R (@?P1 e1) (@?P2 e1)) =>
-      match Reifi.reify_goal with
-      | (?lvar, (fun _: _ => ?x)) =>
+  | |- @eq ?R ?E1 ?E2 =>
+      match Eensatz_solve.Reifi.reify_goal with
+      | (?lvar, ?x, ?v) =>
           let b := eval cbv delta [List.last] iota beta match
-                   in (List.last x (PEc 0%Z))
+                       in (List.last x (PEc 0%Z))
+          in
+          let b := constr: (PEopp b) in
+          let l := constr: (List.removelast x) in
+          let n := eval compute in (List.length l) in
+          repeat NsatzTactic.equalities_to_goal cr;
+          match goal with
+            |- ?g =>
+              let lb := Eensatz_solve.hterm R g in
+              intros;
+              match reify_h lvar lb with
+              | (?fv, ?le) =>
+                let l := constr: (List.rev_append le l) in
+                let le := constr: (b :: l) in
+                let lpol := eval compute in le in
+                match lpol with
+                | ?p2::?lp2 => Eensatz_solve.ensatz_solve p2 lp2 n fv v info
+                | ?g => idtac "polynomial not in the ideal"
+                end
+              end
+            end
+           end
+  | |- @ex _ (fun e1 : _ => @eq ?R (@?P1 e1) (@?P2 e1)) =>
+      match Ensatz_solve.Reifi.reify_goal with
+      | (?lvar, (fun _: _ => ?x)) =>
+          let b :=
+            eval cbv delta [List.last] iota beta match
+                in (List.last x (PEc 0%Z))
           in
           let b := constr: (PEopp b) in
           let l := constr: (List.removelast x) in
@@ -507,7 +757,7 @@ Local Ltac ensatz_default info :=
           repeat NsatzTactic.equalities_to_goal cr;
           match goal with
            |- ?g =>
-             let lb := hterm R g in
+             let lb := Ensatz_solve.hterm R g in
              intros;
              match reify_h lvar lb with
              | (?fv, ?le) =>
@@ -515,13 +765,13 @@ Local Ltac ensatz_default info :=
                 let le := constr: (b :: l) in
                 let lpol := eval compute in le in
                 match lpol with
-                 | ?p2::?lp2 => ensatz_solve cr R p2 lp2 n fv info
+                 | ?p2::?lp2 => Ensatz_solve.ensatz_solve cr R p2 lp2 n fv info
                  | ?g => idtac "polynomial not in the ideal"
                  end
              end
         end
     end
-end.
+  end.
 
 Tactic Notation "ensatz" := ensatz_default 1%Z.
 


### PR DESCRIPTION
This PR introduce the `ensatz` tactic that can prove automatically goals of the form:

 ```math 
     \begin{array}{l}
    \forall X_1, \ldots, X_n \in A, \\
    P_1(X_1, \ldots, X_n) = Q_1(X_1, \ldots, X_n), \ldots, P_s(X_1, \ldots, X_n) = Q_s(X_1, \ldots, X_n) \\
    \vdash \exists Y_1, \ldots, Y_m \in A, 
    P(X_1, \ldots, X_n) = Y_1 * Q'_1(X_1, \ldots, X_n) + \dots + Y_m * Q'_m(X_1, \ldots, X_n)
    \end{array}
```
Tests have be added to the test-suite in file `test-suite/success/ENsatz.v`.

- [x] Added / updated **documentation**:

An entry to the sphinx documentation of `Rocq` is available [here](https://github.com/lyonel2017/coq/blob/doc-ensatz/doc/sphinx/addendum/nsatz.rst) and ready for a PR.


- [x] Added **changelog**.
