### PR TITLE
CI-test dune build on Alpine Linux

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,0 +1,41 @@
+name: CI (Alpine)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  alpine:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - alpine: 'edge'
+#        - alpine: 'latest-stable'
+
+    runs-on: ubuntu-latest
+    name: alpine-${{ matrix.alpine }}
+
+    concurrency:
+      group: ${{ github.workflow }}-alpine-${{ matrix.alpine }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - uses: jirutka/setup-alpine@v1
+      with:
+        branch: ${{ matrix.alpine }}
+        extra-repositories: https://dl-cdn.alpinelinux.org/alpine/edge/testing
+        packages: rocq dune
+    - name: dune build -p rocq-stdlib
+      shell: alpine.sh {0}
+      run: dune build -p rocq-stdlib


### PR DESCRIPTION
This shaves 2 minutes (~40%) off the time until first useful CI feedback ([experiment](https://github.com/andres-erbsen/stdlib/actions/runs/15426576433?pr=1), [control](https://github.com/andres-erbsen/stdlib/actions/runs/15426576177?pr=1)).
