### PR TITLE
nsatz: resolve domain early and thread the instance

### DIFF
--- a/test-suite/output/NsatzGuessOnce.out
+++ b/test-suite/output/NsatzGuessOnce.out
@@ -1,0 +1,2 @@
+Debug: 1: looking for Integral_domain with backtracking
+Debug: 1.1: exact Zdi on Integral_domain, 0 subgoal(s)

--- a/test-suite/output/NsatzGuessOnce.v
+++ b/test-suite/output/NsatzGuessOnce.v
@@ -1,0 +1,4 @@
+From Stdlib Require Import ZArith Nsatz.
+Set Typeclasses Debug.
+Lemma test (x y : Z) : x = y -> y = x.
+Proof. nsatz. Qed.

--- a/theories/setoid_ring/Cring.v
+++ b/theories/setoid_ring/Cring.v
@@ -94,7 +94,8 @@ Ltac cring_gen :=
   match goal with
     |- ?g =>
       let lterm := lterm_goal g in
-      let reif := list_reifyl0 lterm in
+      let R_ring := lazymatch type of lterm with @list ?T => constr:(_ :> Ring (T:=T)) end in
+      let reif := list_reifyl0 R_ring lterm in
         match reif with
           | (?fv, ?lexpr) =>
            (*idtac "variables:";idtac fv;
@@ -247,7 +248,8 @@ Ltac cring_simplify_gen a hyp :=
       | _::_ => a
       | _ => constr:(a::nil)
     end in
-   let reif := list_reifyl0 lterm in
+    let R_ring := lazymatch type of lterm with @list ?T => constr:(_ :> Ring (T:=T)) end in
+    let reif := list_reifyl0 R_ring lterm in
     match reif with
       | (?fv, ?lexpr) => idtac lterm; idtac fv; idtac lexpr;
       let n := eval compute in (length fv) in


### PR DESCRIPTION
This is essentially a follow-up to https://github.com/rocq-prover/rocq/pull/18325; it's also a way towards https://github.com/rocq-prover/stdlib/pull/155 without https://github.com/rocq-prover/rocq/issues/20695. Fiat-crypto nsatz already includes this change, and this PR is one more step towards reconciling the two.


<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/stdlib/blob/master/CONTRIBUTING.md

Changelog: https://github.com/coq/stdlib/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/stdlib/blob/master/doc/README.md
Sphinx: https://github.com/coq/stdlib/blob/master/doc/sphinx/README.rst

Overlays: https://github.com/coq/stdlib/blob/master/dev/doc/README-CI.md
