### PR TITLE
Fix extraction of N.eqb and N.eq_dec in ExtrOcamlZBigInt

### DIFF
--- a/theories/extraction/ExtrOcamlZBigInt.v
+++ b/theories/extraction/ExtrOcamlZBigInt.v
@@ -87,8 +87,8 @@ Extract Constant N.div =>
 Extract Constant N.modulo =>
  "(fun a b -> if Big_int_Z.eq_big_int b Big_int_Z.zero_big_int
   then a else Big_int_Z.mod_big_int a b)".
-Extract Constant Z.eqb => "Big_int_Z.eq_big_int".
-Extract Constant Z.eq_dec => "Big_int_Z.eq_big_int".
+Extract Constant N.eqb => "Big_int_Z.eq_big_int".
+Extract Constant N.eq_dec => "Big_int_Z.eq_big_int".
 Extract Constant N.compare =>
  "(fun x y -> let s = Big_int_Z.compare_big_int x y in
   if s = 0 then Eq else if s < 0 then Lt else Gt)".


### PR DESCRIPTION
@Lysxia could you have a look?  I believe this was probably just a typo in https://github.com/rocq-prover/stdlib/commit/ed79c16c93ad1cc1c9138dd1a95c31aa31b6575b