### PR TITLE
[build] Fix missing deps in dune rule for All.v file

### DIFF
--- a/theories/dune
+++ b/theories/dune
@@ -1,7 +1,10 @@
 (include_subdirs qualified)
+
+; We omit All.v as not to block on rocq-core build
 (coq.theory
  (name Stdlib)
- (package rocq-stdlib))
+ (package rocq-stdlib)
+ (modules :standard \ All))
 
 (env
  (dev
@@ -10,5 +13,5 @@
 
 (rule
  (targets All.v)
- (deps All.sh (source_tree .))
+ (deps (package rocq-core) All.sh (source_tree .))
  (action (with-stdout-to %{targets} (run env bash ./All.sh))))


### PR DESCRIPTION
This fixes a bug for composed builds, introduce in #167.

As the rule stands, dune will try to generate the All.v file before both `rocq` and `Corelib.Init.Prelude.vo` have been built, which are both needed for the script.

Unfortunately, given the way rocq and prelude work, we need to depend on the full `rocq-core` package, so things are in the expected places before the generation of `All.v`.

This would linearize the stdlib build: we cannot run `coqdep` now for the
`Stdlib` until the whole `rocq-core` package is built.

We mitigate this by excluding `All.v` from the list of modules in the
`Stdlib` coq.theory file.
