### PR TITLE
Added new lemma: mod_false_spec

### DIFF
--- a/theories/Numbers/Natural/Abstract/NBits.v
+++ b/theories/Numbers/Natural/Abstract/NBits.v
@@ -1312,6 +1312,13 @@ Proof.
  - now rewrite ones_spec_low, mod_pow2_bits_low, andb_true_r.
 Qed.
 
+Lemma mod_false_spec :
+  forall a n j, testbit a n = false -> testbit (a mod 2 ^ j) n = false.
+Proof.
+  intros a n j H. rewrite <- land_ones. rewrite land_spec. 
+  rewrite H. rewrite Bool.andb_false_l. reflexivity.
+Qed.
+
 Lemma land_ones_low : forall a n, log2 a < n ->
  land a (ones n) == a.
 Proof.

--- a/theories/Numbers/Natural/Abstract/NBits.v
+++ b/theories/Numbers/Natural/Abstract/NBits.v
@@ -1312,7 +1312,7 @@ Proof.
  - now rewrite ones_spec_low, mod_pow2_bits_low, andb_true_r.
 Qed.
 
-Lemma mod_false_spec :
+Lemma testbit_false_mod_pow2 :
   forall a n j, testbit a n = false -> testbit (a mod 2 ^ j) n = false.
 Proof.
   intros a n j H. rewrite <- land_ones. rewrite land_spec. 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **mod_false_spec**.

I added and proved this lemma to the `NBits.v` file:
```
Lemma mod_false_spec :
  forall a n j, testbit a n = false -> testbit (a mod 2 ^ j) n = false.
```