### PR TITLE
adds Nat.add_simpl_l and Nat.add_add_simpl_l_l 

### DIFF
--- a/theories/Numbers/Natural/Abstract/NSub.v
+++ b/theories/Numbers/Natural/Abstract/NSub.v
@@ -66,6 +66,21 @@ intros n m. rewrite <- add_sub_assoc by (apply le_refl).
 rewrite sub_diag; now rewrite add_0_r.
 Qed.
 
+Definition add_simpl_r := add_sub.
+
+Theorem add_simpl_l : forall n m, (n + m) - n == m.
+Proof.
+intros n m. rewrite add_comm. apply add_sub.
+Qed.
+
+Theorem add_add_simpl_l_l n m p : (n + m) - (n + p) == m - p.
+Proof.
+induct n.
+  now rewrite 2!add_0_l.
+intros n Ih. 
+rewrite 2!add_succ_l. now rewrite sub_succ.
+Qed.
+
 Theorem sub_add : forall n m, n <= m -> (m - n) + n == m.
 Proof.
 intros n m H. rewrite add_comm. rewrite add_sub_assoc by assumption.


### PR DESCRIPTION
These lemmas mirror the lemmas by the same name on integers.

Here is the argument: Z.add_simpl_l exists, users would expect Nat.add_simpl_l to exist (a corresponding lemma
used to exist, named minus_plus, but it cannot be replaced by a single theorem).

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/stdlib/blob/master/CONTRIBUTING.md

Changelog: https://github.com/coq/stdlib/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/stdlib/blob/master/doc/README.md
Sphinx: https://github.com/coq/stdlib/blob/master/doc/sphinx/README.rst

Overlays: https://github.com/coq/stdlib/blob/master/dev/doc/README-CI.md
